### PR TITLE
Adds Flatiron/union support to Passport

### DIFF
--- a/lib/passport/http/request.js
+++ b/lib/passport/http/request.js
@@ -1,9 +1,18 @@
 /**
  * Module dependencies.
  */
-var http = require('http')
-  , req = http.IncomingMessage.prototype;
-
+ 
+// If flatiron/union is being used, then bind the following
+// functions to the RoutingStream Prototype
+try {
+    var union = require('union')
+    , req = union.RoutingStream.prototype;
+}
+// Otherwise, bind to the native http.req prototype
+catch (ex) {
+    var http = require('http')
+    , req = http.IncomingMessage.prototype;
+}
 
 /**
  * Intiate a login session for `user`.


### PR DESCRIPTION
Fixes the following issue:
````
  ],
  "stack": [
    "TypeError: Object [object Object] has no method 'logIn'",
    "    at /Users/zeus.lalkaka/Soapbox/app.js:137:21",
    "    at Context.<anonymous> (/Users/zeus.lalkaka/Soapbox/node_modules/passport/lib/passport/middleware/authenticate.js:71:16)",
    "    at Context.<anonymous> (/Users/zeus.lalkaka/Soapbox/node_modules/passport/lib/passport/context/http/actions.js:21:25)",
    "    at Strategy.success (native)",
    "    at /Users/zeus.lalkaka/Soapbox/node_modules/passport-local/lib/passport-local/strategy.js:79:10",
    "    at /Users/zeus.lalkaka/Soapbox/app.js:51:16",
    "    at findByUsername (/Users/zeus.lalkaka/Soapbox/app.js:32:14)",
    "    at Array.0 (/Users/zeus.lalkaka/Soapbox/app.js:47:7)",
    "    at EventEmitter._tickCallback (node.js:192:40)"
  ],
  "level": "error",
  "message": "uncaughtException"
}
````
