### PR TITLE
add support for options.failureCall

### DIFF
--- a/lib/passport/middleware/authenticate.js
+++ b/lib/passport/middleware/authenticate.js
@@ -115,6 +115,14 @@ module.exports = function authenticate(name, options, callback) {
           req.flash(type, msg);
         }
       }
+      if (options.failureCall) {
+        if (typeof options.failureCall === 'function') {
+          options.failureCall(req);
+        } else {
+          return next(new Error('failureCall type must be a function, got type: ' + typeof options.failureCall));
+        }
+      }      
+      
       if (options.failureRedirect) {
         return res.redirect(options.failureRedirect);
       }


### PR DESCRIPTION
to be able to do something like this:

passport.authenticate('google', { failureRedirect: '/login', failureCall: function(req){  if (req.session) { req.session.destroy(function(err){ console.log('session destroyed.'); });}}}),
