### PR TITLE
Add ServerResponse#redirect for Connect apps

### DIFF
--- a/lib/passport/http/response.js
+++ b/lib/passport/http/response.js
@@ -1,0 +1,43 @@
+/**
+ * Module dependencies.
+ */
+var http = require('http')
+  , res = http.ServerResponse.prototype
+  , statusCodes = http.STATUS_CODES;
+
+
+/**
+ * Redirect to the given `url` with optional response `status`
+ * defaulting to 302.
+ *
+ * Examples:
+ *
+ *    res.redirect('/foo/bar');
+ *    res.redirect('http://example.com');
+ *    res.redirect(301, 'http://example.com');
+ *    res.redirect('../login'); // /blog/post/1 -> /blog/login
+ *
+ * @param {Number} code
+ * @param {String} url
+ * @api public
+ */
+
+res.redirect = function(url){
+  var app = this.app
+    , status = 302;
+
+  // allow status / url
+  if (2 == arguments.length) {
+    status = url;
+    url = arguments[1];
+  }
+
+  body = statusCodes[status] + '. Redirecting to ' + url;
+
+  // Respond
+  this.statusCode = status;
+  this.setHeader('Location', url);
+  this.setHeader('Content-Length', Buffer.byteLength(body));
+  this.end(body);
+};
+

--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -410,3 +410,4 @@ exports.strategies.SessionStrategy = SessionStrategy;
  * HTTP extensions.
  */
 require('./http/request');
+require('./http/response');


### PR DESCRIPTION
Express implements response.redirect, but Connect does not. This makes passport play more nicely with Connect-based apps.
