### PR TITLE
Update lib/passport/middleware/authenticate.js

### DIFF
--- a/lib/passport/middleware/authenticate.js
+++ b/lib/passport/middleware/authenticate.js
@@ -107,7 +107,11 @@ module.exports = function authenticate(name, options, callback) {
         var type = flash.type || challenge.type || 'error';
         var msg = flash.message || challenge.message || challenge;
         if (typeof msg == 'string') {
-          req.flash(type, msg);
+          if(req.flash) {
+            req.flash(type, msg);
+          } else {
+            res.message(type, msg);
+          }
         }
       }
       if (options.failureRedirect) {
@@ -163,7 +167,11 @@ module.exports = function authenticate(name, options, callback) {
           var type = flash.type || info.type || 'success';
           var msg = flash.message || info.message || info;
           if (typeof msg == 'string') {
-            req.flash(type, msg);
+            if(req.flash) {
+              req.flash(type, msg);
+            } else {
+              res.message(type, msg);
+            }
           }
         }
         if (options.assignProperty) {


### PR DESCRIPTION
A little fix to check req.flash support (has been dropped in express 3). 

This is the middleware to use for the messages:

app.response.message = function(type, msg){
  // reference `req.session` via the `this.req` reference
  var sess = this.req.session;
  // simply add the msg to an array for later
  sess.messages = sess.messages || [];
  sess.messages.push(msg);
  return this;
};
