### PR TITLE
Passed the request object into the deserializers.

### DIFF
--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -255,7 +255,7 @@ Passport.prototype.serializeUser = function(fn, done) {
  *
  * @api public
  */
-Passport.prototype.deserializeUser = function(fn, done) {
+Passport.prototype.deserializeUser = function(fn, req, done) {
   if (typeof fn === 'function') {
     return this._deserializers.push(fn);
   }
@@ -282,7 +282,7 @@ Passport.prototype.deserializeUser = function(fn, done) {
     }
     
     try {
-      layer(obj, function(e, u) { pass(i + 1, e, u); } )
+      layer(obj, req, function(e, u) { pass(i + 1, e, u); } )
     } catch(e) {
       return done(e);
     }

--- a/lib/passport/strategies/session.js
+++ b/lib/passport/strategies/session.js
@@ -37,7 +37,7 @@ SessionStrategy.prototype.authenticate = function(req) {
   
   var self = this;
   if (req._passport.session.user) {
-    req._passport.instance.deserializeUser(req._passport.session.user, function(err, user) {
+    req._passport.instance.deserializeUser(req._passport.session.user, req, function(err, user) {
       if (err) { return self.error(err); }
       if (!user) {
         delete req._passport.session.user;


### PR DESCRIPTION
... the application specific deserializer, so that we can pull out request specific properties, like a request specific database connection reference.
