### PR TITLE
Add message-body and Content-Type to 302 Redirect (RFC2616, Section 4.3)

### DIFF
--- a/lib/passport/context/http/actions.js
+++ b/lib/passport/context/http/actions.js
@@ -67,7 +67,7 @@ actions.redirect = function(url, status) {
   // Respond
   res.statusCode = status;
   res.setHeader('Location', url);
-  res.end(body);
+  res.end(status == 304 ? null : body);
 }
 
 /**


### PR DESCRIPTION
[RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3) specifies that any 30x request (except for 304) must include a message body (and thus a Content-Type).

Some HTTP proxies will deny the HTTP Response to a 302 that does not contain a Content-Type in the header.
