### PR TITLE
Use redirect method on response if it's defined

### DIFF
--- a/lib/passport/context/http/actions.js
+++ b/lib/passport/context/http/actions.js
@@ -46,9 +46,23 @@ actions.fail = function(challenge, status) {
  * @api public
  */
 actions.redirect = function(url, status) {
-  this.res.statusCode = status || 302;
-  this.res.setHeader('Location', url);
-  this.res.end();
+  var res = this.res;
+  // If possible use redirect method on the response
+  if (typeof res.redirect == 'function') {
+    // Assume Express API, optional status param comes first
+    if (status) {
+      res.redirect(status, url);
+    }
+    else {
+      res.redirect(url);
+    }
+  }
+  // Otherwise fall back to native methods
+  else {
+    res.statusCode = status || 302;
+    res.setHeader('Location', url);
+    res.end();
+  }
 }
 
 /**


### PR DESCRIPTION
Trying to get Passport working with Geddy. What I have is a little hacky, but this is the last hurdle. I need to be able to run code in the controller before finishing out the redirect. I have an adapter layer around Geddy's req/resp objects that let this work. Really nice work with this, and I'm looking forward to getting people using Passport as the de facto auth setup in Geddy.
