### PR TITLE
Add failure callback option to authenticate middleware

### DIFF
--- a/lib/passport/middleware/authenticate.js
+++ b/lib/passport/middleware/authenticate.js
@@ -123,6 +123,9 @@ module.exports = function authenticate(name, options, callback) {
       if (options.failureRedirect) {
         return res.redirect(options.failureRedirect);
       }
+      if (options.failureCallback) {
+        return options.failureCallback(req, res);
+      }
     
       // When failure handling is not delegated to the application, the default
       // is to respond with 401 Unauthorized.  Note that the WWW-Authenticate


### PR DESCRIPTION
It is very useful to be able to react more abstract to an authentication failure than just redirecting the user or sending a predefined failure message (setting response header or evaluating the exact reason of failure for example).
