### PR TITLE
Generalized Web-Server support

### DIFF
--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -21,6 +21,7 @@ function Passport() {
   this._serializers = [];
   this._deserializers = [];
   this._infoTransformers = [];
+  this._plugin = null;
   
   this._userProperty = 'user';
   
@@ -104,6 +105,10 @@ Passport.prototype.initialize = function(options) {
   options = options || {};
   this._userProperty = options.userProperty || 'user';
   
+  if (this._plugin && this._plugin.initialize) {
+    return this._plugin.initialize().bind(this);
+  }
+  
   return initialize().bind(this);
 }
 
@@ -170,6 +175,10 @@ Passport.prototype.session = function() {
  * @api public
  */
 Passport.prototype.authenticate = function(strategy, options, callback) {
+  if (this._plugin && this._plugin.authenticate) {
+    return this._plugin.authenticate(strategy, options, callback).bind(this);
+  }
+  
   return authenticate(strategy, options, callback).bind(this);
 }
 


### PR DESCRIPTION
Moved the Hapi-specific code out and added a simple way to replace the required functions.  This way passport stays lean yet can accommodate Hapi and other non-express web servers also.  

Obviously, I'm open to changes. Please let me know and I'll make the requisite changes on the Hapi end.  Thanks for the help, Jared!
