### PR TITLE
Expose middleware name

### DIFF
--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -126,14 +126,19 @@ Passport.prototype.framework = function(fw) {
  * @api public
  */
 Passport.prototype.initialize = function(options) {
+  var passport = this;
   options = options || {};
   this._userProperty = options.userProperty || 'user';
-  
+
   if (this._framework && this._framework.initialize) {
     return this._framework.initialize().bind(this);
   }
-  
-  return initialize().bind(this);
+
+  var middleware = initialize();
+
+  return function passportInit(req, res, next) {
+    middleware.call(passport, req, res, next);
+  };
 }
 
 /**
@@ -199,11 +204,16 @@ Passport.prototype.session = function() {
  * @api public
  */
 Passport.prototype.authenticate = function(strategy, options, callback) {
+  var passport = this;
   if (this._framework && this._framework.authenticate) {
     return this._framework.authenticate(strategy, options, callback).bind(this);
   }
-  
-  return authenticate(strategy, options, callback).bind(this);
+
+  var middleware = authenticate(strategy, options, callback);
+
+  return function passportAuth(req, res, next) {
+      middleware.call(passport, req, res, next);
+  };
 }
 
 /**


### PR DESCRIPTION
This code is fully equivalent, with one difference useful for debugging: when I do console.log(app.stack) I will see something like:

```
[ { route: '', handle: [Function: query] },
  { route: '', handle: [Function: expressInit] },
  { route: '', handle: [Function: assetsCompiler] },
  { route: '', handle: [Function: static] },
  { route: '', handle: [Function: bodyParser] },
  { route: '', handle: [Function: cookieParser] },
  { route: '', handle: [Function: session] },
  { route: '', handle: [Function: methodOverride] },
  { route: '', handle: [Function: passportInit] },
  { route: '', handle: [Function: passportAuth] },
  { route: '', handle: [Function: router] },
  { route: '', handle: [Function: errorHandler] } ]
```

instead of

```
[ { route: '', handle: [Function: query] },
  { route: '', handle: [Function: expressInit] },
  { route: '', handle: [Function: assetsCompiler] },
  { route: '', handle: [Function: static] },
  { route: '', handle: [Function: bodyParser] },
  { route: '', handle: [Function: cookieParser] },
  { route: '', handle: [Function: session] },
  { route: '', handle: [Function: methodOverride] },
  { route: '', handle: [Function] },
  { route: '', handle: [Function] },
  { route: '', handle: [Function: router] },
  { route: '', handle: [Function: errorHandler] } ]
```

And second reason: code without binds works a little bit faster; not much, but this "optimization" may be useful in that case, because it's middleware.
