### PR TITLE
Deserialize user might need to handle logout.

### DIFF
--- a/lib/passport/strategies/session.js
+++ b/lib/passport/strategies/session.js
@@ -47,7 +47,12 @@ SessionStrategy.prototype.authenticate = function(req, options) {
     
     var paused = options.pauseStream ? pause(req) : null;
     req._passport.instance.deserializeUser(su, function(err, user) {
-      if (err) { return self.error(err); }
+      if (err) {
+          if (err.passportLogout!=null){
+              delete req._passport.session.user;
+          }
+          return self.error(err);
+      }
       if (!user) {
         delete req._passport.session.user;
         self.pass();


### PR DESCRIPTION
There are situations sometimes when user deserialize function might detect problems with current information in cookies and wants to logout user. Becouse there is limited access to req we introduced additional attribue to err object called 'passportLogout'. If this attribute it set to the err object session error handler simply cleans the current session.

Example of usage:

```
passportDeserializeUser = function(id, done) {
  return findById(id, function(err, user) {
    if (err) {
      err.passportLogout = true;
    }
    return done(err, user);
  });
};

```
