### PR TITLE
Only call req.flash() when it is a defined function

### DIFF
--- a/lib/passport/middleware/authenticate.js
+++ b/lib/passport/middleware/authenticate.js
@@ -60,7 +60,7 @@ module.exports = function authenticate(name, options, callback) {
     options = {};
   }
   options = options || {};
-  
+
   // Cast `name` to an array, allowing authentication to pass through a chain of
   // strategies.  The first strategy to succeed, redirect, or error will halt
   // the chain.  Authentication failures will proceed through each strategy in
@@ -74,13 +74,13 @@ module.exports = function authenticate(name, options, callback) {
   if (!Array.isArray(name)) {
     name = [ name ];
   }
-  
+
   return function authenticate(req, res, next) {
     var passport = this;
-    
+
     // accumulator for failures from each strategy in the chain
     var failures = [];
-    
+
     function allFailed() {
       if (callback) {
         if (failures.length == 1) {
@@ -91,23 +91,24 @@ module.exports = function authenticate(name, options, callback) {
           return callback(null, false, challenges, statuses);
         }
       }
-      
+
       // Strategies are ordered by priority.  For the purpose of flashing a
       // message, the first failure will be displayed.
       var failure = failures[0] || {}
         , challenge = failure.challenge || {};
-    
+
       if (options.failureFlash) {
         var flash = options.failureFlash;
         if (typeof flash == 'string') {
           flash = { type: 'error', message: flash };
         }
         flash.type = flash.type || 'error';
-      
+
         var type = flash.type || challenge.type || 'error';
         var msg = flash.message || challenge.message || challenge;
         if (typeof msg == 'string') {
-          if (req.flash && getClass.call(req.flash) == '[object Function]') {
+
+          if (req.flash && Object.prototype.toString.call(req.flash).match(/^\[object\s(.*)\]$/)[1] == '[object Function]') {
             req.flash(type, msg);
           } else {
             req.session.flash[type] = [msg];
@@ -127,7 +128,7 @@ module.exports = function authenticate(name, options, callback) {
       if (options.failureRedirect) {
         return res.redirect(options.failureRedirect);
       }
-    
+
       // When failure handling is not delegated to the application, the default
       // is to respond with 401 Unauthorized.  Note that the WWW-Authenticate
       // header will be set according to the strategies in use (see
@@ -135,7 +136,7 @@ module.exports = function authenticate(name, options, callback) {
       // will be included in the response.
       var rchallenge = []
         , rstatus;
-      
+
       for (var j = 0, len = failures.length; j < len; j++) {
         var failure = failures[j]
           , challenge = failure.challenge || {}
@@ -144,40 +145,40 @@ module.exports = function authenticate(name, options, callback) {
           status = challenge;
           challenge = null;
         }
-          
+
         rstatus = rstatus || status;
         if (typeof challenge == 'string') {
           rchallenge.push(challenge)
         }
       }
-    
+
       res.statusCode = rstatus || 401;
       if (rchallenge.length) {
         res.setHeader('WWW-Authenticate', rchallenge);
       }
       res.end('Unauthorized');
     }
-    
+
     (function attempt(i) {
       var delegate = {};
       delegate.success = function(user, info) {
         if (callback) {
           return callback(null, user, info);
         }
-      
+
         info = info || {}
-      
+
         if (options.successFlash) {
           var flash = options.successFlash;
           if (typeof flash == 'string') {
             flash = { type: 'success', message: flash };
           }
           flash.type = flash.type || 'success';
-        
+
           var type = flash.type || info.type || 'success';
           var msg = flash.message || info.message || info;
           if (typeof msg == 'string') {
-            if (req.flash && getClass.call(req.flash) == '[object Function]') {
+            if (req.flash && Object.prototype.toString.call(req.flash).match(/^\[object\s(.*)\]$/)[1] == '[object Function]') {
               req.flash(type, msg);
             } else {
               req.session.flash[type] = [msg];
@@ -198,7 +199,7 @@ module.exports = function authenticate(name, options, callback) {
           req[options.assignProperty] = user;
           return next();
         }
-      
+
         req.logIn(user, options, function(err) {
           if (err) { return next(err); }
           if (options.authInfo || options.authInfo === undefined) {
@@ -210,7 +211,7 @@ module.exports = function authenticate(name, options, callback) {
           } else {
             complete();
           }
-        
+
           function complete() {
             if (options.successReturnToOrRedirect) {
               var url = options.successReturnToOrRedirect;
@@ -233,21 +234,21 @@ module.exports = function authenticate(name, options, callback) {
         failures.push({ challenge: challenge, status: status });
         attempt(i + 1);
       }
-    
+
       var layer = name[i];
       // If no more strategies exist in the chain, authentication has failed.
       if (!layer) { return allFailed(); }
-    
+
       // Get the strategy, which will be used as prototype from which to create
       // a new instance.  Action functions will then be bound to the strategy
       // within the context of the HTTP request/response pair.
       var prototype = passport._strategy(layer);
       if (!prototype) { return next(new Error('no strategy registered under name: ' + layer)); }
-    
+
       var strategy = Object.create(prototype);
       var context = new Context(delegate, req, res, next);
       augment(strategy, actions, context);
-    
+
       strategy.authenticate(req, options);
     })(0); // attempt
   }


### PR DESCRIPTION
When using certain frameworks (e.g. CompoundJS), req.flash is not a function, which causes the below error:

TypeError: Object #<IncomingMessage> has no method 'flash'

This pull request detects if req.flash() is indeed a function. If it is, it uses that default functionality; otherwise, it sets a session variable which Compound uses in rendering flash messages.
