### PR TITLE
REF: https://github.com/jaredhanson/passport/issues/111 adding passing o...

### DIFF
--- a/lib/passport/http/request.js
+++ b/lib/passport/http/request.js
@@ -44,7 +44,7 @@ req.logIn = function(user, options, done) {
       if (err) { self[property] = null; return done(err); }
       self._passport.session.user = obj;
       done();
-    });
+    }, self);
   } else {
     done && done();
   }

--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -252,7 +252,7 @@ Passport.prototype.authorize = function(strategy, options, callback) {
  *
  * @api public
  */
-Passport.prototype.serializeUser = function(fn, done) {
+Passport.prototype.serializeUser = function(fn, done, req) {
   if (typeof fn === 'function') {
     return this._serializers.push(fn);
   }
@@ -276,7 +276,7 @@ Passport.prototype.serializeUser = function(fn, done) {
     }
     
     try {
-      layer(user, function(e, o) { pass(i + 1, e, o); } )
+      layer(user, function(e, o) { pass(i + 1, e, o); }, req);
     } catch(e) {
       return done(e);
     }
@@ -296,7 +296,7 @@ Passport.prototype.serializeUser = function(fn, done) {
  *
  * @api public
  */
-Passport.prototype.deserializeUser = function(fn, done) {
+Passport.prototype.deserializeUser = function(fn, done, req) {
   if (typeof fn === 'function') {
     return this._deserializers.push(fn);
   }
@@ -323,7 +323,7 @@ Passport.prototype.deserializeUser = function(fn, done) {
     }
     
     try {
-      layer(obj, function(e, u) { pass(i + 1, e, u); } )
+      layer(obj, function(e, u) { pass(i + 1, e, u); }, req);
     } catch(e) {
       return done(e);
     }

--- a/lib/passport/strategies/session.js
+++ b/lib/passport/strategies/session.js
@@ -62,7 +62,7 @@ SessionStrategy.prototype.authenticate = function(req, options) {
       if (paused) {
         paused.resume();
       }
-    });
+    }, req);
   } else {
     self.pass();
   }


### PR DESCRIPTION
Here is the issue this relates to:
https://github.com/jaredhanson/passport/issues/111

I realized there was another pull request for this same thing after I created my fork.
https://github.com/jaredhanson/passport/pull/160

the solution in that pull request by @CamShaft is much more elegant because he does type checking to ensure backwards compatibility so that the callback can remain the last parameter.

Mine is simpler and a bit more dirty, adding req as the last parameter.

Maybe this pull request will evidence the need for the feature as my need is the same as @CamShaft's (need the domain the request was for in order to properly deserialize the user).

thanks,
-Matt
