### PR TITLE
Enhanced the res.end('Unauthorized') response

### DIFF
--- a/lib/passport/middleware/authenticate.js
+++ b/lib/passport/middleware/authenticate.js
@@ -136,14 +136,19 @@ module.exports = function authenticate(name, options, callback) {
         var failure = failures[j]
           , challenge = failure.challenge || {}
           , status = failure.status;
+
         if (typeof challenge == 'number') {
           status = challenge;
           challenge = null;
         }
           
         rstatus = rstatus || status;
+
+        // Push the error message on to the rchallenge array.
         if (typeof challenge == 'string') {
-          rchallenge.push(challenge)
+          rchallenge.push({ name: 'General', message: challenge })
+        } else {
+          rchallenge.push({ name: challenge.name, message: challenge.message });
         }
       }
     
@@ -151,7 +156,17 @@ module.exports = function authenticate(name, options, callback) {
       if (rchallenge.length) {
         res.setHeader('WWW-Authenticate', rchallenge);
       }
-      res.end('Unauthorized');
+
+      // If we have challenges then return a JSON String 
+      // of the names and messages in addition to the header 
+      // message.
+
+      if (rchallenge.length > 0) {
+        res.end( JSON.stringify(rchallenge) );
+      } else {
+        res.end('Unauthorized');
+      }
+
     }
     
     (function attempt(i) {


### PR DESCRIPTION
I have found that when using Passport within an app does not handle errors, like an API, I have little way to communicate helpful error messages to the endpoint request. This would make the 401 - Unauthorized response a bit more robust.

Example for Local Strategy:

passport.use("local", new LocalStrategy(function(username, password, done) {

```
store.findUserByUsername(username, function(err, user) {
  if (err) 
    return done(null, false, { name: 'Error', message: err.message } );

  if (!user) {
    return done(null, false, { name: 'NoAccountFound', message: 'Invalid Username and Password.' } );
  } else {
    done(null, user);
  }

});
```

  }
));

Returning:

401 

[
  {
    "name": "NoAccountFound",
    "message": "Invalid Username and Password."
  }
]
