### PR TITLE
Throw error if callback is undefined

### DIFF
--- a/lib/passport/http/request.js
+++ b/lib/passport/http/request.js
@@ -33,12 +33,17 @@ req.logIn = function(user, options, done) {
     done = options;
     options = {};
   }
+  
   options = options || {};
   var property = this._passport.instance._userProperty || 'user';
   var session = (options.session === undefined) ? true : options.session;
   
   this[property] = user;
   if (session) {
+    if (typeof done !== 'function') {
+      throw new Error('Required callback function undefined');
+    }
+    
     var self = this;
     this._passport.instance.serializeUser(user, function(err, obj) {
       if (err) { self[property] = null; return done(err); }


### PR DESCRIPTION
Throws error when req.login callback function is missing (and is using session).

This should make it easier to debug when you [accidentally] forget to place a callback function into req.login.
