### PR TITLE
Allow framework-handled authorization

### DIFF
--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -235,8 +235,14 @@ Passport.prototype.authenticate = function(strategy, options, callback) {
  * @api public
  */
 Passport.prototype.authorize = function(strategy, options, callback) {
+  var fwAuthorize = this._framework && (this._framework.authorize || this._framework.authenticate);
+
   options = options || {};
   options.assignProperty = 'account';
+
+  if (fwAuthorize) {
+    return fwAuthorize(strategy, options, callback).bind(this);
+  }
   
   return authenticate(strategy, options, callback).bind(this);
 }


### PR DESCRIPTION
Allow a framework to override authorize specifically, falling back to using the framework's authenticate if an authorize-specific override is not needed.
