### PR TITLE
simply require package.json to get current version

### DIFF
--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -431,7 +431,7 @@ exports = module.exports = new Passport();
 /**
  * Framework version.
  */
-require('pkginfo')(module, 'version');
+exports.version = require('../../package.json').version;
 
 /**
  * Expose constructors.


### PR DESCRIPTION
This avoids unnecessary dependency,
and is a common pattern used to get
current version.
