### PR TITLE
switch the arguments to the redirect function

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -291,7 +291,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         if (typeof res.redirect == 'function') {
           // If possible use redirect method on the response
           // Assume Express API, optional status is last
-          res.redirect(url, status || 302);
+          res.redirect(status || 302, url);
         } else {
           // Otherwise fall back to native methods
           res.statusCode = status || 302;


### PR DESCRIPTION
Express expects these arguments to be the other way around.  The original code throws a TypeError: Object 302 has no method 'indexOf'.  My new change properly redirects (tested using passport-google-oauth 0.1.5, passport 0.2.0, express 3.0.0-rc3).  Unfortunately, your unit tests no longer pass -- there are two relating to this functionality that now fail, and I'm not familiar enough with your unit test framework to figure out why they're failing.  I think something in the unit test framework might also have the arguments backwards.
