### PR TITLE
Fix: change parameters order in res.redirect

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -291,7 +291,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         if (typeof res.redirect == 'function') {
           // If possible use redirect method on the response
           // Assume Express API, optional status is last
-          res.redirect(url, status || 302);
+          res.redirect(status || 302, url);
         } else {
           // Otherwise fall back to native methods
           res.statusCode = status || 302;


### PR DESCRIPTION
Optional status code should be first. It's described in docs http://expressjs.com/api.html#res.redirect and can be checked in sources https://github.com/visionmedia/express/blob/master/lib/response.js#L664
