### PR TITLE
Update Readme to not use plain-text passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ application must be configured.
 
     passport.use(new LocalStrategy(
       function(username, password, done) {
-        User.findOne({ username: username, password: password }, function (err, user) {
-          done(err, user);
+        User.findOne({ username: username }, function (err, user) {
+          if (err) { return done(err); }
+          if (!user) { return done(null, false); }
+          if (!user.verifyPassword(password)) { return done(null, false); }
+          return done(null, user);
         });
       }
     ));


### PR DESCRIPTION
Update the readme documentation to not store passwords as plain-text (or at least not require them to be stored as plain text).

The code is taken directly from  the [Passport-Local readme](https://github.com/jaredhanson/passport-local#configure-strategy), so it is not new.
