### PR TITLE
Update argument order for Express Response redirect #229

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -291,7 +291,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         if (typeof res.redirect == 'function') {
           // If possible use redirect method on the response
           // Assume Express API, optional status is last
-          res.redirect(url, status || 302);
+          res.redirect(status || 302, url);
         } else {
           // Otherwise fall back to native methods
           res.statusCode = status || 302;


### PR DESCRIPTION
This is to address issue #229, making response code argument first when used as per latest Express documentation and Connect middleware.

Benefit is this makes Passport more compatible with non-Express frameworks.
