### PR TITLE
pass options to framework's #initialize method

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -132,7 +132,7 @@ Authenticator.prototype.initialize = function(options) {
   options = options || {};
   this._userProperty = options.userProperty || 'user';
   
-  return this._framework.initialize(this);
+  return this._framework.initialize(this, options);
 };
 
 /**


### PR DESCRIPTION
I'm trying to implement a custom framework for passport, and this little change can help me a lot.
