### PR TITLE
deserialize undefined user

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -333,7 +333,7 @@ Authenticator.prototype.deserializeUser = function(fn, req, done) {
     if (err || user) { return done(err, user); }
     // a valid user existed when establishing the session, but that user has
     // since been removed
-    if (user === null || user === false) { return done(null, false); }
+    if (user === null || user === false || user === undefined) { return done(null, false); }
     
     var layer = stack[i];
     if (!layer) {


### PR DESCRIPTION
A user was valid when the session was established and has been deleted now. When we find this user in the database, it could be return as `undefined`.
