### PR TITLE
reflect custom userProperty in session

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -47,7 +47,7 @@ req.logIn = function(user, options, done) {
     var self = this;
     this._passport.instance.serializeUser(user, this, function(err, obj) {
       if (err) { self[property] = null; return done(err); }
-      self._passport.session.user = obj;
+      self._passport.session[property] = obj;
       done();
     });
   } else {
@@ -69,7 +69,7 @@ req.logOut = function() {
   
   this[property] = null;
   if (this._passport && this._passport.session) {
-    delete this._passport.session.user;
+    delete this._passport.session[property];
   }
 };
 

--- a/lib/strategies/session.js
+++ b/lib/strategies/session.js
@@ -37,9 +37,9 @@ util.inherits(SessionStrategy, Strategy);
 SessionStrategy.prototype.authenticate = function(req, options) {
   if (!req._passport) { return this.error(new Error('passport.initialize() middleware not in use')); }
   options = options || {};
-
   var self = this
-    , su = req._passport.session.user;
+    , property = req._passport.instance && req._passport.instance._userProperty || 'user'
+    , su = req._passport.session[property];
   if (su || su === 0) {
     // NOTE: Stream pausing is desirable in the case where later middleware is
     //       listening for events emitted from request.  For discussion on the
@@ -49,14 +49,14 @@ SessionStrategy.prototype.authenticate = function(req, options) {
     req._passport.instance.deserializeUser(su, req, function(err, user) {
       if (err) { return self.error(err); }
       if (!user) {
-        delete req._passport.session.user;
+        delete req._passport.session[property];
         self.pass();
         if (paused) {
           paused.resume();
         }
         return;
       }
-      var property = req._passport.instance._userProperty || 'user';
+
       req[property] = user;
       self.pass();
       if (paused) {

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -258,7 +258,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should serialize user', function() {
-        expect(req._passport.session.user).to.equal('1');
+        expect(req._passport.session[passport._userProperty]).to.equal('1');
       });
     });
     
@@ -361,7 +361,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should clear serialized user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req._passport.session[passport._userProperty]).to.be.undefined;
       });
     });
     
@@ -388,7 +388,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should clear serialized user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req._passport.session[passport._userProperty]).to.be.undefined;
       });
     });
     

--- a/test/strategies/session.test.js
+++ b/test/strategies/session.test.js
@@ -172,7 +172,7 @@ describe('SessionStrategy', function() {
             done(null, { id: user });
           };
           req._passport.session = {};
-          req._passport.session.user = '123456';
+          req._passport.session[req._passport.instance._userProperty] = '123456';
         })
         .authenticate();
     });


### PR DESCRIPTION
This PR makes passport use the custom 'userProperty' as the session variable. So instead of session.user regardless of the 'userProperty' we can have it be session[userProperty].

This simple change makes it significantly easier to use passport for multi-tenanted applications.

Without this PR one can only be logged as one type of user at a time since it is always persisted to the same session variable.

Tests are also modified to reflect changes (i.e. I effectively changed all instances of session.user to session[userProperty])
