### PR TITLE
Fix express deprecated msg - Use res.redirect(status, url) instead

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -291,7 +291,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         if (typeof res.redirect == 'function') {
           // If possible use redirect method on the response
           // Assume Express API, optional status is last
-          res.redirect(status, url || 302);
+          res.redirect(status || 302, url);
         } else {
           // Otherwise fall back to native methods
           res.statusCode = status || 302;


### PR DESCRIPTION
In expressjs 4.6.1 I am getting this deprecation warning: 

"express deprecated res.redirect(ur, status): Use res.redirect(status, url) instead node_modules/passport/lib/middleware/authenticate.js:294:15"

So I fixed it for you!  ;)

Note: my editor also removed excess spaces automatically - sorry about all the changes below - line 294 is the only real change.  
