### PR TITLE
redirect(status, url) instead of redirect(url, st)

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -122,7 +122,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         }
       }
       if (options.failureRedirect) {
-        return res.redirect(options.failureRedirect);
+        return res.redirect(302, options.failureRedirect);
       }
     
       // When failure handling is not delegated to the application, the default
@@ -235,10 +235,10 @@ module.exports = function authenticate(passport, name, options, callback) {
                 url = req.session.returnTo;
                 delete req.session.returnTo;
               }
-              return res.redirect(url);
+              return res.redirect(302, url);
             }
             if (options.successRedirect) {
-              return res.redirect(options.successRedirect);
+              return res.redirect(302, options.successRedirect);
             }
             next();
           }
@@ -291,7 +291,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         if (typeof res.redirect == 'function') {
           // If possible use redirect method on the response
           // Assume Express API, optional status is last
-          res.redirect(url, status || 302);
+          res.redirect(status || 302, url);
         } else {
           // Otherwise fall back to native methods
           res.statusCode = status || 302;


### PR DESCRIPTION
res.redirect(url, status) is deprecated in Express 4.6.x
See. https://github.com/visionmedia/express/releases/tag/4.6.0
