### PR TITLE
Fixed warning

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -291,7 +291,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         if (typeof res.redirect == 'function') {
           // If possible use redirect method on the response
           // Assume Express API, optional status is last
-          res.redirect(url, status || 302);
+          res.redirect(status || 302, url);
         } else {
           // Otherwise fall back to native methods
           res.statusCode = status || 302;


### PR DESCRIPTION
This way of calling that method is deprecated - res.redirect(url, status).
