### PR TITLE
Add redirectStatus option to passport.authenticate

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -30,6 +30,7 @@ var http = require('http')
  *   - `failureFlash`     True to flash failure messages or a string to use as a flash
  *                        message for failures (overrides any from the strategy itself).
  *   - `assignProperty`   Assign the object provided by the verify callback to given property
+ *   - `redirectStatus`   Status to use when redirecting using the above options (default 302)
  *
  * An optional `callback` can be supplied to allow the application to override
  * the default manner in which authentication attempts are handled.  The
@@ -73,6 +74,7 @@ module.exports = function authenticate(passport, name, options, callback) {
     options = {};
   }
   options = options || {};
+  options.redirectStatus = options.redirectStatus || 302;
   
   var multi = true;
   
@@ -142,7 +144,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         }
       }
       if (options.failureRedirect) {
-        return res.redirect(options.failureRedirect);
+        return res.redirect(options.failureRedirect, options.redirectStatus);
       }
     
       // When failure handling is not delegated to the application, the default
@@ -255,10 +257,10 @@ module.exports = function authenticate(passport, name, options, callback) {
                 url = req.session.returnTo;
                 delete req.session.returnTo;
               }
-              return res.redirect(url);
+              return res.redirect(url, options.redirectStatus);
             }
             if (options.successRedirect) {
-              return res.redirect(options.successRedirect);
+              return res.redirect(options.successRedirect, options.redirectStatus);
             }
             next();
           }

--- a/test/middleware/authenticate.fail.test.js
+++ b/test/middleware/authenticate.fail.test.js
@@ -56,7 +56,7 @@ describe('middleware/authenticate', function() {
     var request, response;
 
     before(function(done) {
-      chai.connect.use('express', authenticate(passport, 'fail', { failureRedirect: 'http://www.example.com/login' }))
+      chai.connect.use('express', authenticate(passport, 'fail', { failureRedirect: 'http://www.example.com/login', redirectStatus: 303 }))
         .req(function(req) {
           request = req;
         })
@@ -72,7 +72,7 @@ describe('middleware/authenticate', function() {
     });
     
     it('should redirect', function() {
-      expect(response.statusCode).to.equal(302);
+      expect(response.statusCode).to.equal(303);
       expect(response.getHeader('Location')).to.equal('http://www.example.com/login');
     });
   });

--- a/test/middleware/authenticate.success.test.js
+++ b/test/middleware/authenticate.success.test.js
@@ -168,7 +168,7 @@ describe('middleware/authenticate', function() {
     var request, response;
 
     before(function(done) {
-      chai.connect.use('express', authenticate(passport, 'success', { successRedirect: 'http://www.example.com/account' }))
+      chai.connect.use('express', authenticate(passport, 'success', { successRedirect: 'http://www.example.com/account', redirectStatus: 303 }))
         .req(function(req) {
           request = req;
           
@@ -196,7 +196,7 @@ describe('middleware/authenticate', function() {
     });
     
     it('should redirect', function() {
-      expect(response.statusCode).to.equal(302);
+      expect(response.statusCode).to.equal(303);
       expect(response.getHeader('Location')).to.equal('http://www.example.com/account');
     });
   });


### PR DESCRIPTION
As per [here](http://stackoverflow.com/a/4764456/665488) and [here](http://serverfault.com/a/391182/96805), I'd like to make my login do its redirect with a 303, but passport defaults to 302. Rather than write my own custom strategy that does the redirect manually, I'd like to continue using `LocalStrategy` from [passport-local](https://github.com/jaredhanson/passport-local), and instead supply the redirect status code as an option to `authenticate`, alongside `successRedirect` and `failureRedirect`. I've updated a couple of the tests to show how it would be used. Note that this pull request preserves existing behaviour for those who don't use the option.
