### PR TITLE
do not initialize session if uneeded.  helps express-session not create ...

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -47,7 +47,14 @@ req.logIn = function(user, options, done) {
     var self = this;
     this._passport.instance.serializeUser(user, this, function(err, obj) {
       if (err) { self[property] = null; return done(err); }
+      if(!self._passport.session) {
+        self._passport.session = {};
+      }
       self._passport.session.user = obj;
+      if(!self.session) {
+        self.session = {};
+      }
+      self.session[self._passport.instance._key] = self._passport.session;        
       done();
     });
   } else {

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -50,15 +50,8 @@ module.exports = function initialize(passport) {
     if (req.session && req.session[passport._key]) {
       // load data from existing session
       req._passport.session = req.session[passport._key];
-    } else if (req.session) {
-      // initialize new session
-      req.session[passport._key] = {};
-      req._passport.session = req.session[passport._key];
-    } else {
-      // no session is available
-      req._passport.session = {};
     }
-    
+
     next();
   };
 };

--- a/lib/strategies/session.js
+++ b/lib/strategies/session.js
@@ -38,8 +38,11 @@ SessionStrategy.prototype.authenticate = function(req, options) {
   if (!req._passport) { return this.error(new Error('passport.initialize() middleware not in use')); }
   options = options || {};
 
-  var self = this
-    , su = req._passport.session.user;
+  var self = this, 
+      su;
+  if(req._passport.session) 
+      su = req._passport.session.user;
+
   if (su || su === 0) {
     // NOTE: Stream pausing is desirable in the case where later middleware is
     //       listening for events emitted from request.  For discussion on the

--- a/package.json
+++ b/package.json
@@ -44,6 +44,28 @@
     "node": ">= 0.4.0"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha --reporter spec --require test/bootstrap/node test/*.test.js test/**/*.test.js"
-  }
+    "test": "mocha --reporter spec --require test/bootstrap/node test/*.test.js test/**/*.test.js"
+  },
+  "gitHead": "4dce9d99a009fdec8a6b83a8cbc99d119a73c561",
+  "_id": "passport@0.2.1",
+  "_shasum": "a7d34c07b30fb605be885edbc8c93e5142e38574",
+  "_from": "passport@^0.2.1",
+  "_npmVersion": "1.4.23",
+  "_npmUser": {
+    "name": "jaredhanson",
+    "email": "jaredhanson@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "jaredhanson",
+      "email": "jaredhanson@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "a7d34c07b30fb605be885edbc8c93e5142e38574",
+    "tarball": "http://registry.npmjs.org/passport/-/passport-0.2.1.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/passport/-/passport-0.2.1.tgz",
+  "readme": "ERROR: No README data found!"
 }

--- a/test/authenticator.middleware.test.js
+++ b/test/authenticator.middleware.test.js
@@ -39,9 +39,8 @@ describe('Authenticator', function() {
         expect(passport._userProperty).to.equal('user');
       });
     
-      it('should initialize namespace within session', function() {
-        expect(request.session.passport).to.be.an('object');
-        expect(Object.keys(request.session.passport)).to.have.length(0);
+      it('should not initialize namespace within session', function() {
+        expect(request.session.passport).to.be.undefined;
       });
     
       it('should expose authenticator on internal request property', function() {
@@ -51,8 +50,7 @@ describe('Authenticator', function() {
       });
     
       it('should expose session storage on internal request property', function() {
-        expect(request._passport.session).to.be.an('object');
-        expect(Object.keys(request._passport.session)).to.have.length(0);
+        expect(request._passport.session).to.be.undefined;
       });
     });
     
@@ -82,8 +80,7 @@ describe('Authenticator', function() {
       });
     
       it('should initialize namespace within session', function() {
-        expect(request.session.passport).to.be.an('object');
-        expect(Object.keys(request.session.passport)).to.have.length(0);
+        expect(request.session.passport).to.be.undefined;
       });
     
       it('should expose authenticator on internal request property', function() {
@@ -93,8 +90,7 @@ describe('Authenticator', function() {
       });
     
       it('should expose session storage on internal request property', function() {
-        expect(request._passport.session).to.be.an('object');
-        expect(Object.keys(request._passport.session)).to.have.length(0);
+        expect(request._passport.session).to.be.undefined;
       });
     });
     

--- a/test/middleware/initialize.test.js
+++ b/test/middleware/initialize.test.js
@@ -39,8 +39,7 @@ describe('middleware/initialize', function() {
     });
     
     it('should expose empty object as session storage on internal request property', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(Object.keys(request._passport.session)).to.have.length(0);
+      expect(request._passport.session).to.be.undefined;
     });
   });
   
@@ -67,8 +66,7 @@ describe('middleware/initialize', function() {
     });
     
     it('should initialize namespace within session', function() {
-      expect(request.session.passport).to.be.an('object');
-      expect(Object.keys(request.session.passport)).to.have.length(0);
+      expect(request.session.passport).to.be.undefined;
     });
     
     it('should expose authenticator on internal request property', function() {
@@ -78,8 +76,7 @@ describe('middleware/initialize', function() {
     });
     
     it('should expose session storage on internal request property', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(Object.keys(request._passport.session)).to.have.length(0);
+      expect(request._passport.session).to.be.undefined;
     });
   });
   


### PR DESCRIPTION
...sessions when using saveUninitialized: false option

passport creates an empty passport object {} on req.session every request.  this causes express-session saveUninitialized: false not to work properly.  this patch may have implications for downstream strategies but i've fixed up the tests on passport core to make sure the session is not defined instead of {}.

Please review this for inclusion as it solves:

https://github.com/jaredhanson/passport/issues/259


