### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ middleware for [Node.js](http://nodejs.org/).
 
 Passport's sole purpose is to authenticate requests, which it does through an
 extensible set of plugins known as _strategies_.  Passport does not mount
-routes or assume any particular database schema, which maximizes flexiblity and
+routes or assume any particular database schema, which maximizes flexibility and
 allows application-level decisions to be made by the developer.  The API is
 simple: you provide Passport a request to authenticate, and Passport provides
 hooks for controlling what occurs when authentication succeeds or fails.


### PR DESCRIPTION
While reading the documentation for Passport I noticed the word 'flexibility' was spelled incorrectly on line 15. This pull request fixes the spelling error.