### PR TITLE
docs: remove references to express's old app.configure() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,14 @@ with the required `passport.initialize()` middleware.  If your application uses
 persistent login sessions (recommended, but not required), `passport.session()`
 middleware must also be used.
 
-    app.configure(function() {
-      app.use(express.static(__dirname + '/../../public'));
-      app.use(express.cookieParser());
-      app.use(express.bodyParser());
-      app.use(express.session({ secret: 'keyboard cat' }));
-      app.use(passport.initialize());
-      app.use(passport.session());
-      app.use(app.router);
-    });
+    var app = express();
+    app.use(express.static(__dirname + '/../../public'));
+    app.use(express.cookieParser());
+    app.use(express.bodyParser());
+    app.use(express.session({ secret: 'keyboard cat' }));
+    app.use(passport.initialize());
+    app.use(passport.session());
+    app.use(app.router);
 
 #### Authenticate Requests
 

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -116,13 +116,9 @@ Authenticator.prototype.framework = function(fw) {
  *
  * Examples:
  *
- *     app.configure(function() {
- *       app.use(passport.initialize());
- *     });
+ *     app.use(passport.initialize());
  *
- *     app.configure(function() {
- *       app.use(passport.initialize({ userProperty: 'currentUser' }));
- *     });
+ *     app.use(passport.initialize({ userProperty: 'currentUser' }));
  *
  * @param {Object} options
  * @return {Function} middleware
@@ -215,12 +211,10 @@ Authenticator.prototype.authorize = function(strategy, options, callback) {
  *
  * Examples:
  *
- *     app.configure(function() {
- *       app.use(connect.cookieParser());
- *       app.use(connect.session({ secret: 'keyboard cat' }));
- *       app.use(passport.initialize());
- *       app.use(passport.session());
- *     });
+ *     app.use(connect.cookieParser());
+ *     app.use(connect.session({ secret: 'keyboard cat' }));
+ *     app.use(passport.initialize());
+ *     app.use(passport.session());
  *
  * Options:
  *   - `pauseStream`      Pause the request stream before deserializing the user

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -21,12 +21,10 @@
  *
  * Examples:
  *
- *     app.configure(function() {
- *       app.use(connect.cookieParser());
- *       app.use(connect.session({ secret: 'keyboard cat' }));
- *       app.use(passport.initialize());
- *       app.use(passport.session());
- *     });
+ *     app.use(connect.cookieParser());
+ *     app.use(connect.session({ secret: 'keyboard cat' }));
+ *     app.use(passport.initialize());
+ *     app.use(passport.session());
  *
  *     passport.serializeUser(function(user, done) {
  *       done(null, user.id);


### PR DESCRIPTION
app.configure() has been removed from the latest version of express.

StackOverflow post:
http://stackoverflow.com/questions/18637148/using-app-configure-in-express

Github issue:
https://github.com/strongloop/express/issues/936

Error if you try to use `app.configure` with express 4:

```
11:16:32 web.1  | app.configure(function() {
11:16:32 web.1  |     ^
11:16:32 web.1  | TypeError: Object function (req, res, next) {
11:16:32 web.1  |     app.handle(req, res, next);
11:16:32 web.1  |   } has no method 'configure'
```
