### PR TITLE
Define main entry module to be a js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "url": "http://www.opensource.org/licenses/MIT"
     }
   ],
-  "main": "./lib",
+  "main": "./lib/index.js",
   "dependencies": {
     "passport-strategy": "1.x.x",
     "pause": "0.0.1"


### PR DESCRIPTION
Although node.js understands if "main" is a directory name, some tools (madge) requires that it is an actual module file. This is how it is specified in https://docs.npmjs.com/files/package.json also. 