### PR TITLE
Return result of pass()

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -336,7 +336,7 @@ Authenticator.prototype.deserializeUser = function(fn, req, done) {
     
     
     function deserialized(e, u) {
-      pass(i + 1, e, u);
+      return pass(i + 1, e, u);
     }
     
     try {


### PR DESCRIPTION
`deserialized` is usually passed as `done` in middleware. Which leads to code like this:

``` js
passport.deserializeUser( function deserializeUser( id, done ) {
    return pg.db.user.readById( id )
        .then( function gotUser( user ) {
            return done( null, user );
        } )
        .catch( errors.RecordNotFoundError, function handleInvalidLogin( error ) {
            // A user with the given ID does not exist.
            // Either the cookie was manipulated (unlikely) or a cookie from a different FairManager installation
            // was provided.
            log.warn( error.message );
            return done( null, null );
        } )
        .catch( function handleInvalidUser( error ) {
            log.error( error );
            // Returning a falsey value for the user, causes a logout.
            return done( null, null );
        } );
} );
```

However, this will raise a `Warning: a promise was created in a  handler but was not returned from it` warning with bluebird, because `deserialized` does not return the result of `pass`.
