### PR TITLE
Proposed fix for challenge / response

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -311,6 +311,33 @@ module.exports = function authenticate(passport, name, options, callback) {
         res.setHeader('Content-Length', '0');
         res.end();
       };
+
+      /**
+       * Send raw `data` without indicating pass or fail.
+       *
+       * Options:
+       * - `json`       boolean indicating whether data should be sent as JSON, defaults to _false_ which sends data using `res.send()`
+       * - `type`       the `Content-Type` in the HTTP response
+       * - `status`     the HTTP status code to send, defaults to _200_
+       * 
+       * @param {Object} data
+       * @param {Object} options
+       */
+      strategy.raw = function (data, options) {
+        var status = options.status || 200;
+        var json = options.json || false;
+        var type = options.type || null;
+
+        if (type) {
+          res.type(type);
+        }
+
+        if (json) {
+          res.status(status).json(data);
+        } else {
+          res.status(status).send(data);
+        }
+      };
       
       /**
        * Pass without making a success or fail decision.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Simple, unobtrusive authentication for Node.js.",
   "keywords": [
     "express",


### PR DESCRIPTION
This pull request adds a new strategy augmentation similar to `strategy.pass()` and `strategy.fail()` that is intended to support challenge / response type authentication protocols as mentioned in #488 . The new method is `strategy.raw()`, which is roughly the same as `res.send()`. It supports options for `res.json()`, `res.type()` and `res.status()` since those seem like those would be the most useful features to people.