### PR TITLE
Added support for requiring multiple strategies

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -75,6 +75,7 @@ module.exports = function authenticate(passport, name, options, callback) {
   options = options || {};
   
   var multi = true;
+  var requiredAll = options.requiredAll || false;
   
   // Cast `name` to an array, allowing authentication to pass through a chain of
   // strategies.  The first strategy to succeed, redirect, or error will halt
@@ -101,7 +102,7 @@ module.exports = function authenticate(passport, name, options, callback) {
     // accumulator for failures from each strategy in the chain
     var failures = [];
     
-    function allFailed() {
+    function authFailed() {
       if (callback) {
         if (!multi) {
           return callback(null, false, failures[0].challenge, failures[0].status);
@@ -177,7 +178,12 @@ module.exports = function authenticate(passport, name, options, callback) {
     (function attempt(i) {
       var layer = name[i];
       // If no more strategies exist in the chain, authentication has failed.
-      if (!layer) { return allFailed(); }
+      if (!layer) { 
+        if (!requiredAll || (requiredAll && failures.length > 0)) {
+          return authFailed();
+        }
+        return next();
+      }
     
       // Get the strategy, which will be used as prototype from which to create
       // a new instance.  Action functions will then be bound to the strategy
@@ -266,11 +272,14 @@ module.exports = function authenticate(passport, name, options, callback) {
           if (options.authInfo !== false) {
             passport.transformAuthInfo(info, req, function(err, tinfo) {
               if (err) { return next(err); }
-              req.authInfo = tinfo;
-              complete();
+              req.authInfo = req.authInfo || {}
+              for (key in tinfo) {
+                req.authInfo[key] = tinfo[key]
+              }
+              !requiredAll ? complete() : attempt(i + 1);
             });
           } else {
-            complete();
+            !requiredAll ? complete() : attempt(i + 1);
           }
         });
       };


### PR DESCRIPTION
If you need to require few strategies on one request just add {requiredAll: true} for options.
Example:

passport.authenticate(['auth-user', 'auth-project'], {requiredAll: true})