### PR TITLE
Regenerating the session id before logging in the user

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -34,32 +34,35 @@ req.logIn = function(user, options, done) {
     options = {};
   }
   options = options || {};
-  
+
   var property = 'user';
   if (this._passport && this._passport.instance) {
     property = this._passport.instance._userProperty || 'user';
   }
   var session = (options.session === undefined) ? true : options.session;
-  
-  this[property] = user;
+
   if (session) {
     if (!this._passport) { throw new Error('passport.initialize() middleware not in use'); }
     if (typeof done != 'function') { throw new Error('req#login requires a callback function'); }
-    
+
     var self = this;
     this._passport.instance.serializeUser(user, this, function(err, obj) {
       if (err) { self[property] = null; return done(err); }
       if (!self._passport.session) {
         self._passport.session = {};
       }
-      self._passport.session.user = obj;
-      if (!self.session) {
-        self.session = {};
-      }
-      self.session[self._passport.instance._key] = self._passport.session;
-      done();
+
+      self.session.regenerate(function(err) {
+        if (err) { self[property] = null; return done(err); }
+        self[property] = user;
+        self._passport.session.user = obj;
+        self.session[self._passport.instance._key] = self._passport.session;
+        done();
+      });
+
     });
   } else {
+    this[property] = user;
     done && done();
   }
 };
@@ -75,7 +78,7 @@ req.logOut = function() {
   if (this._passport && this._passport.instance) {
     property = this._passport.instance._userProperty || 'user';
   }
-  
+
   this[property] = null;
   if (this._passport && this._passport.session) {
     delete this._passport.session.user;
@@ -93,7 +96,7 @@ req.isAuthenticated = function() {
   if (this._passport && this._passport.instance) {
     property = this._passport.instance._userProperty || 'user';
   }
-  
+
   return (this[property]) ? true : false;
 };
 

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -8,366 +8,377 @@ require('../../lib/framework/connect').__monkeypatchNode();
 
 
 describe('http.ServerRequest', function() {
-  
+
   describe('prototoype', function() {
     var req = new http.IncomingMessage();
-    
+
     it('should be extended with login', function() {
       expect(req.login).to.be.an('function');
       expect(req.login).to.equal(req.logIn);
     });
-    
+
     it('should be extended with logout', function() {
       expect(req.logout).to.be.an('function');
       expect(req.logout).to.equal(req.logOut);
     });
-    
+
     it('should be extended with isAuthenticated', function() {
       expect(req.isAuthenticated).to.be.an('function');
     });
-    
+
     it('should be extended with isUnauthenticated', function() {
       expect(req.isUnauthenticated).to.be.an('function');
     });
   });
-  
+
   describe('#login', function() {
-    
+
+    var passport, sessionDouble, req;
+    sessionDouble = require('./../session_test_double');
+
+    var resetPassport = function() {
+      passport = new Passport();
+      sessionDouble.clear();
+      req = new http.IncomingMessage();
+      req._passport = {};
+      req._passport.instance = passport;
+      req.session = sessionDouble;
+    }
+
     describe('not establishing a session', function() {
-      var passport = new Passport();
-      
-      var req = new http.IncomingMessage();
-      req._passport = {};
-      req._passport.instance = passport;
-      req._passport.session = {};
-      
       var error;
-      
       before(function(done) {
+        resetPassport();
         var user = { id: '1', username: 'root' };
-        
         req.login(user, { session: false }, function(err) {
           error = err;
           done();
         });
       });
-      
+
       it('should not error', function() {
         expect(error).to.be.undefined;
       });
-      
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
-      
+
       it('should set user', function() {
         expect(req.user).to.be.an('object');
         expect(req.user.id).to.equal('1');
         expect(req.user.username).to.equal('root');
       });
-      
+
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(sessionDouble.empty).to.be.true;
       });
     });
-    
+
     describe('not establishing a session and setting custom user property', function() {
-      var passport = new Passport();
-      passport._userProperty = 'currentUser';
-      
-      var req = new http.IncomingMessage();
-      req._passport = {};
-      req._passport.instance = passport;
-      req._passport.session = {};
-      
       var error;
-      
       before(function(done) {
+        resetPassport();
+        passport._userProperty = 'currentUser';
         var user = { id: '1', username: 'root' };
-        
+
         req.login(user, { session: false }, function(err) {
           error = err;
           done();
         });
       });
-      
+
       it('should not error', function() {
         expect(error).to.be.undefined;
       });
-      
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
-      
+
       it('should not set user', function() {
         expect(req.user).to.be.undefined;
       });
-      
+
       it('should set custom user', function() {
         expect(req.currentUser).to.be.an('object');
         expect(req.currentUser.id).to.equal('1');
         expect(req.currentUser.username).to.equal('root');
       });
-      
+
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(sessionDouble.empty).to.be.true;
       });
     });
-    
+
     describe('not establishing a session and invoked without a callback', function() {
-      var passport = new Passport();
-      
-      var req = new http.IncomingMessage();
-      req._passport = {};
-      req._passport.instance = passport;
-      req._passport.session = {};
-      
-      var user = { id: '1', username: 'root' };
-      req.login(user, { session: false });
-      
+      before(function() {
+        resetPassport();
+        var user = { id: '1', username: 'root' };
+        req.login(user, { session: false });
+      });
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
-      
+
       it('should set user', function() {
         expect(req.user).to.be.an('object');
         expect(req.user.id).to.equal('1');
         expect(req.user.username).to.equal('root');
       });
-      
+
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(sessionDouble.empty).to.be.true;
       });
     });
-    
+
     describe('not establishing a session, without passport.initialize() middleware', function() {
-      var req = new http.IncomingMessage();
-      
       var error;
-      
+
       before(function(done) {
         var user = { id: '1', username: 'root' };
-        
+
         req.login(user, { session: false }, function(err) {
           error = err;
           done();
         });
       });
-      
+
       it('should not error', function() {
         expect(error).to.be.undefined;
       });
-      
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
-      
+
       it('should set user', function() {
         expect(req.user).to.be.an('object');
         expect(req.user.id).to.equal('1');
         expect(req.user.username).to.equal('root');
       });
     });
-    
+
     describe('establishing a session', function() {
-      var passport = new Passport();
-      passport.serializeUser(function(user, done) {
-        done(null, user.id);
-      });
-      
-      var req = new http.IncomingMessage();
-      req._passport = {};
-      req._passport.instance = passport;
-      req._passport.session = {};
-      
       var error;
-      
       before(function(done) {
+        resetPassport();
+        passport.serializeUser(function(user, done) {
+          done(null, user.id);
+        });
         var user = { id: '1', username: 'root' };
-        
         req.login(user, function(err) {
           error = err;
           done();
         });
+
       });
-      
+
       it('should not error', function() {
         expect(error).to.be.undefined;
       });
-      
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
-      
+
       it('should set user', function() {
         expect(req.user).to.be.an('object');
         expect(req.user.id).to.equal('1');
         expect(req.user.username).to.equal('root');
       });
-      
+
       it('should serialize user', function() {
-        expect(req._passport.session.user).to.equal('1');
+        expect(sessionDouble.data).to.eql({
+          '1': {},
+          '2': {
+            passport: { user: '1' }
+          }
+        })
       });
     });
-    
+
     describe('establishing a session and setting custom user property', function() {
-      var passport = new Passport();
-      passport.serializeUser(function(user, done) {
-        done(null, user.id);
-      });
-      passport._userProperty = 'currentUser';
-      
-      var req = new http.IncomingMessage();
-      req._passport = {};
-      req._passport.instance = passport;
-      req._passport.session = {};
-      
       var error;
-      
       before(function(done) {
+        resetPassport();
+        passport._userProperty = 'currentUser';
+        passport.serializeUser(function(user, done) {
+          done(null, user.id);
+        });
         var user = { id: '1', username: 'root' };
-        
+
         req.login(user, function(err) {
           error = err;
           done();
         });
       });
-      
+
       it('should not error', function() {
         expect(error).to.be.undefined;
       });
-      
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
-      
+
       it('should not set user', function() {
         expect(req.user).to.be.undefined;
       });
-      
+
       it('should set custom user', function() {
         expect(req.currentUser).to.be.an('object');
         expect(req.currentUser.id).to.equal('1');
         expect(req.currentUser.username).to.equal('root');
       });
-      
+
       it('should serialize user', function() {
         expect(req._passport.session.user).to.equal('1');
       });
     });
-    
-    describe('encountering an error when serializing to session', function() {
-      var passport = new Passport();
-      passport.serializeUser(function(user, done) {
-        done(new Error('something went wrong'));
-      });
-      
-      var req = new http.IncomingMessage();
-      req._passport = {};
-      req._passport.instance = passport;
-      req._passport.session = {};
-      
+
+    describe('encountering an error when regenerating the session id', function () {
       var error;
-      
       before(function(done) {
+        resetPassport();
+        sessionDouble.regeneration_should_fail = true;
+        passport.serializeUser(function(user, done) {
+          done(null, user.id);
+        });
         var user = { id: '1', username: 'root' };
-        
+
         req.login(user, function(err) {
           error = err;
           done();
         });
       });
-      
+
       it('should error', function() {
-        expect(error).to.be.an.instanceOf(Error);
-        expect(error.message).to.equal('something went wrong');
+        expect(error).to.equal(sessionDouble.regeneration_error);
       });
-      
+
       it('should not be authenticated', function() {
         expect(req.isAuthenticated()).to.be.false;
         expect(req.isUnauthenticated()).to.be.true;
       });
-      
+
       it('should not set user', function() {
         expect(req.user).to.be.null;
       });
-      
+
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(sessionDouble.empty).to.be.true;
       });
     });
-    
+
+    describe('encountering an error when serializing to session', function() {
+      var error;
+      before(function(done) {
+        resetPassport();
+        var user = { id: '1', username: 'root' };
+
+        passport.serializeUser(function(user, done) {
+          done(new Error('something went wrong'));
+        });
+
+        req.login(user, function(err) {
+          error = err;
+          done();
+        });
+      });
+
+      it('should error', function() {
+        expect(error).to.be.an.instanceOf(Error);
+        expect(error.message).to.equal('something went wrong');
+      });
+
+      it('should not be authenticated', function() {
+        expect(req.isAuthenticated()).to.be.false;
+        expect(req.isUnauthenticated()).to.be.true;
+      });
+
+      it('should not set user', function() {
+        expect(req.user).to.be.null;
+      });
+
+      it('should not serialize user', function() {
+        expect(sessionDouble.empty).to.be.true;
+      });
+    });
+
     describe('establishing a session, without passport.initialize() middleware', function() {
-      var req = new http.IncomingMessage();
+
       var user = { id: '1', username: 'root' };
-      
+
+      before(function() {
+        delete(req._passport);
+      });
+
       it('should throw an exception', function() {
         expect(function() {
           req.login(user, function(err) {});
         }).to.throw(Error, 'passport.initialize() middleware not in use');
       });
     });
-    
+
     describe('establishing a session, but not passing a callback argument', function() {
-      var passport = new Passport();
-      passport.serializeUser(function(user, done) {
-        done(null, user.id);
+
+      before(function () {
+        resetPassport();
+        passport.serializeUser(function(user, done) {
+          done(null, user.id);
+        });
       });
-      
-      var req = new http.IncomingMessage();
-      req._passport = {};
-      req._passport.instance = passport;
-      req._passport.session = {};
-      
-      var user = { id: '1', username: 'root' };
-      
+
       it('should throw an exception', function() {
+        var user = { id: '1', username: 'root' };
         expect(function() {
           req.login(user);
         }).to.throw(Error, 'req#login requires a callback function');
       });
     });
-    
+
   });
-  
-  
+
+
   describe('#logout', function() {
-    
+
     describe('existing session', function() {
       var passport = new Passport();
-      
+
       var req = new http.IncomingMessage();
       req.user = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
       req._passport.session.user = '1';
-      
+
       req.logout();
-      
+
       it('should not be authenticated', function() {
         expect(req.isAuthenticated()).to.be.false;
         expect(req.isUnauthenticated()).to.be.true;
       });
-      
+
       it('should clear user', function() {
         expect(req.user).to.be.null;
       });
-      
+
       it('should clear serialized user', function() {
         expect(req._passport.session.user).to.be.undefined;
       });
     });
-    
+
     describe('existing session and clearing custom user property', function() {
       var passport = new Passport();
-      
+
       var req = new http.IncomingMessage();
       req.currentUser = { id: '1', username: 'root' };
       req._passport = {};
@@ -375,86 +386,86 @@ describe('http.ServerRequest', function() {
       req._passport.instance._userProperty = 'currentUser';
       req._passport.session = {};
       req._passport.session.user = '1';
-      
+
       req.logout();
-      
+
       it('should not be authenticated', function() {
         expect(req.isAuthenticated()).to.be.false;
         expect(req.isUnauthenticated()).to.be.true;
       });
-      
+
       it('should clear user', function() {
         expect(req.currentUser).to.be.null;
       });
-      
+
       it('should clear serialized user', function() {
         expect(req._passport.session.user).to.be.undefined;
       });
     });
-    
+
     describe('existing session, without passport.initialize() middleware', function() {
       var req = new http.IncomingMessage();
       req.user = { id: '1', username: 'root' };
-      
+
       req.logout();
-      
+
       it('should not be authenticated', function() {
         expect(req.isAuthenticated()).to.be.false;
         expect(req.isUnauthenticated()).to.be.true;
       });
-      
+
       it('should clear user', function() {
         expect(req.user).to.be.null;
       });
     });
-    
+
   });
-  
-  
+
+
   describe('#isAuthenticated', function() {
-    
+
     describe('with a user', function() {
       var req = new http.IncomingMessage();
       req.user = { id: '1', username: 'root' };
-      
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
     });
-    
+
     describe('with a user set on custom property', function() {
       var req = new http.IncomingMessage();
       req.currentUser = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = {};
       req._passport.instance._userProperty = 'currentUser';
-      
+
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;
         expect(req.isUnauthenticated()).to.be.false;
       });
     });
-    
+
     describe('without a user', function() {
       var req = new http.IncomingMessage();
-      
+
       it('should not be authenticated', function() {
         expect(req.isAuthenticated()).to.be.false;
         expect(req.isUnauthenticated()).to.be.true;
       });
     });
-    
+
     describe('with a null user', function() {
       var req = new http.IncomingMessage();
       req.user = null;
-      
+
       it('should not be authenticated', function() {
         expect(req.isAuthenticated()).to.be.false;
         expect(req.isUnauthenticated()).to.be.true;
       });
     });
-    
+
   });
-  
+
 });

--- a/test/session_test_double.js
+++ b/test/session_test_double.js
@@ -55,7 +55,7 @@ module.exports = new Proxy({}, {
       return this[prop];
     }
 
-    return this.data[target.id][prop];
+    return this.data[this.id][prop];
   }
 
 });

--- a/test/session_test_double.js
+++ b/test/session_test_double.js
@@ -1,0 +1,61 @@
+/**
+ * Allows to:
+ *   - set and get properties (like session.user = "john")
+ *   - generate new session with new id (like express-session's regenerate)
+ *   - clear the current session (without destroying it)
+ *   - get the internal state for testing purposes
+ *   - simulate id regeneration failure
+ *
+ * The following example of the internal state (session.data)
+ * shows a session that:
+ *  1. had id "1"
+ *  2. held variable "some_key"
+ *  3. was regenerated and got id "2"
+ *  4. held variable "another_key"
+ * {
+ *   1: { some_key: "abc" },
+ *   2: { another_key: "123" }
+ * }
+ *
+ */
+
+module.exports = new Proxy({}, {
+
+  regeneration_should_fail: false,
+  regeneration_error: "forced error",
+  data: {1: {}},
+  id: 1,
+
+  regenerate: function (cb) {
+    this.id += 1;
+    this.data[this.id] = {};
+    cb(this.regeneration_should_fail ? this.regeneration_error : undefined);
+  },
+
+  clear: function () {
+    this.data = {1: {}};
+    this.id = 1;
+  },
+
+  get empty () {
+    return Object.keys(this.data[this.id]).length === 0;
+  },
+
+  set: function (target, prop, val) {
+    if (typeof this[prop] !== 'undefined') {
+      this[prop] = val;
+      return;
+    }
+
+    this.data[this.id][prop] = val;
+  },
+
+  get: function (target, prop) {
+    if (typeof this[prop] !== 'undefined') {
+      return this[prop];
+    }
+
+    return this.data[target.id][prop];
+  }
+
+});


### PR DESCRIPTION
Hello everyone!

This suggested change is about regenerating the session id before putting there the user data. I find it  very helpful as it frees the developer from the need of taking care of how the user data is stored in the session. 

This significantly increases the level of security of apps using passport used by different people on the same device, like in a library on an internet cafe. 

Unfortunately it has some disadvantages. There's a risk that some code may depend on the fact the session id doesn't change, or that some session data will be preserved after logging in. As far as I know, regenerating the session without losing the data is currently impossible with express-session. 

I haven't checked all of the available strategies, so there's a risk that this change breaks some. Taking that and the previous paragraph into account I'd suggest mentioning this in the documentation or version number if it were merged. 

I hope this could make an average node web app a little bit more secure.

I'm looking forward to hearing from you. 