### PR TITLE
Making passport compatible with graphql

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -100,7 +100,7 @@ module.exports = function authenticate(passport, name, options, callback) {
     
     // accumulator for failures from each strategy in the chain
     var failures = [];
-    
+    var auths = {};
     function allFailed() {
       if (callback) {
         if (!multi) {
@@ -358,7 +358,8 @@ module.exports = function authenticate(passport, name, options, callback) {
       
       // ----- END STRATEGY AUGMENTATION -----
     
-      strategy.authenticate(req, options);
+      auths[layer] = strategy.authenticate(req, options);
     })(0); // attempt
+    return auths;
   };
 };


### PR DESCRIPTION
Hi,
So, in this commit I've enabled returning a value from the authenticate method of any strategy.
I've tested it with this strategy [passport-graphql-mongoose](https://github.com/shalkam/passport-graphql-mongoose) that returns a promise instead of depending on callbacks.
I had to do this because if the authentication method is asynchronous, I always get an empty result and the callback takes effect only later on.
Now I can do something like this:
```javascript
  async login(root, params, context, ast) {
    let res = {};
    if (typeof context.req.user === 'undefined') {
      context.req.body.username = params.username;
      context.req.body.password = params.password;
      const auth = passport.authenticate('local')(context.req);
      const user = await auth['local']
        .then(user => {
          context.req.logIn(user, function(err) {
            res = user;
            res.message = 'Logged in successfully!';
          });
        })
        .catch(err => {
          res = err;
        });
    } else {
      res = new Error('Already logged in');
    }
    return res;
  }
```
regards,
Mostafa