### PR TITLE
Fixed Example URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ The following table lists commonly used strategies:
 that uses [passport-local](https://github.com/jaredhanson/passport-local).
 - **Local Strategy**: Refer to the following tutorials for setting up user authentication via LocalStrategy (`passport-local`):
     - Mongo
-      - Express v3x - [Tutorial](http://mherman.org/blog/2016/09/25/node-passport-and-postgres/#.V-govpMrJE5) / [working example](https://github.com/mjhea0/passport-local-knex)
+      - Express v3x - [Tutorial](http://mherman.org/blog/2013/11/11/user-authentication-with-passport-dot-js/) / [working example](https://github.com/passport/express-3.x-local-example)
       - Express v4x - [Tutorial](http://mherman.org/blog/2015/01/31/local-authentication-with-passport-and-express-4/) / [working example](https://github.com/mjhea0/passport-local-express4)
     - Postgres
-      - [Tutorial](http://mherman.org/blog/2015/01/31/local-authentication-with-passport-and-express-4/) / [working example](https://github.com/mjhea0/passport-local-express4)
+      - [Tutorial](http://mherman.org/blog/2016/09/25/node-passport-and-postgres/#.V-govpMrJE5) / [working example](https://github.com/mjhea0/passport-local-knex)
 - **Social Authentication**: Refer to the following tutorials for setting up various social authentication strategies:
     - Express v3x - [Tutorial](http://mherman.org/blog/2013/11/10/social-authentication-with-passport-dot-js/) / [working example](https://github.com/mjhea0/passport-examples)
     - Express v4x - [Tutorial](http://mherman.org/blog/2015/09/26/social-authentication-in-node-dot-js-with-passport) / [working example](https://github.com/mjhea0/passport-social-auth)


### PR DESCRIPTION
Under the examples section of the readme there were several mixed up links. Should be patched up now!