### PR TITLE
Read strategy name from request parameter

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -30,6 +30,10 @@ var http = require('http')
  *   - `failureFlash`     True to flash failure messages or a string to use as a flash
  *                        message for failures (overrides any from the strategy itself).
  *   - `assignProperty`   Assign the object provided by the verify callback to given property
+ *   - `nameFromParam`    Retrieves the name of the strategy from this request parameter.
+ *                        Define a route as follows:
+ *                          app.get('/login/:name(facebook|google)/callback',
+ *                            passport.authenticate(null, { nameFromParam: 'name' })
  *
  * An optional `callback` can be supplied to allow the application to override
  * the default manner in which authentication attempts are handled.  The
@@ -97,6 +101,9 @@ module.exports = function authenticate(passport, name, options, callback) {
       require('../framework/connect').__monkeypatchNode();
     }
     
+    if (options.nameFromParam && req.params[options.nameFromParam]) {
+      name = [req.params[options.nameFromParam]];
+    }
     
     // accumulator for failures from each strategy in the chain
     var failures = [];

--- a/test/middleware/authenticate.success.param.test.js
+++ b/test/middleware/authenticate.success.param.test.js
@@ -1,0 +1,107 @@
+/* global describe, it, expect, before */
+/* jshint expr: true */
+
+var chai = require('chai')
+  , authenticate = require('../../lib/middleware/authenticate')
+  , Passport = require('../..').Passport;
+
+
+describe('middleware/authenticate', function() {
+  
+  describe('with multiple strategies, the first is selected using a param', function() {
+    function StrategyA() {
+    }
+    StrategyA.prototype.authenticate = function(req) {
+      this.success({ username: 'bob-a' });
+    };
+    
+    function StrategyB() {
+    }
+    StrategyB.prototype.authenticate = function(req) {
+      this.success({ username: 'bob-b' });
+    };
+    
+    var passport = new Passport();
+    passport.use('a', new StrategyA());
+    passport.use('b', new StrategyB());
+    
+    var request, error;
+
+    before(function(done) {
+      chai.connect.use(authenticate(passport, null, { nameFromParam: 'name' }))
+        .req(function(req) {
+          request = req;
+          
+          req.params = { name: 'a' };
+          
+          req.logIn = function(user, options, done) {
+            this.user = user;
+            done();
+          };
+        })
+        .next(function(err) {
+          error = err;
+          done();
+        })
+        .dispatch();
+    });
+    
+    it('should not error', function() {
+      expect(error).to.be.undefined;
+    });
+    
+    it('should set user', function() {
+      expect(request.user).to.be.an('object');
+      expect(request.user.username).to.equal('bob-a');
+    });
+  });
+  
+  describe('with multiple strategies, the second is selected using a param', function() {
+    function StrategyA() {
+    }
+    StrategyA.prototype.authenticate = function(req) {
+      this.fail('A challenge');
+    };
+    
+    function StrategyB() {
+    }
+    StrategyB.prototype.authenticate = function(req) {
+      this.success({ username: 'bob-b' });
+    };
+    
+    var passport = new Passport();
+    passport.use('a', new StrategyA());
+    passport.use('b', new StrategyB());
+    
+    var request, error;
+
+    before(function(done) {
+      chai.connect.use(authenticate(passport, null, { nameFromParam: 'name' }))
+        .req(function(req) {
+          request = req;
+
+          req.params = { name: 'b' };
+
+          req.logIn = function(user, options, done) {
+            this.user = user;
+            done();
+          };
+        })
+        .next(function(err) {
+          error = err;
+          done();
+        })
+        .dispatch();
+    });
+    
+    it('should not error', function() {
+      expect(error).to.be.undefined;
+    });
+    
+    it('should set user', function() {
+      expect(request.user).to.be.an('object');
+      expect(request.user.username).to.equal('bob-b');
+    });
+  });
+  
+});


### PR DESCRIPTION
This adds the option `nameFromParam` to the authenticate method.
Set this to a parameter name that is set by the application to dynamically configure the strategy to use.

Example:

```js
app.get('/login/:name(facebook|google)/callback',
  passport.authenticate(null, { nameFromParam: 'name' })
```