### PR TITLE
Fixing issue when running with use_strict option was causing process …

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -122,6 +122,8 @@ module.exports = function authenticate(passport, name, options, callback) {
         var flash = options.failureFlash;
         if (typeof flash == 'string') {
           flash = { type: 'error', message: flash };
+        } else if (typeof flash == 'boolean') {
+          flash = { type: 'error' };
         }
         flash.type = flash.type || 'error';
       


### PR DESCRIPTION
…to crash

This is a fix to an issue when running process in strict mode was causing process to crash.

To reproduce this issue try running Flash Messages example in strict mode. For example below is
route for login:

```
app.post('/login',
  passport.authenticate('local', { successRedirect: '/',
                                   failureRedirect: '/login',
                                   failureFlash: true })
);
```

And start the server in strict mode. For example:

```
node --use_strict ./bin/www
```

And in form try submitting wrong password/email to login route.