### PR TITLE
Factor session access into session manager.

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -29,7 +29,7 @@ function Authenticator() {
  */
 Authenticator.prototype.init = function() {
   this.framework(require('./framework/connect')());
-  this.use(new SessionStrategy());
+  this.use(new SessionStrategy({ key: this._key }, this.deserializeUser.bind(this)));
   this._sm = new SessionManager({ key: this._key }, this.serializeUser.bind(this));
 };
 

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -1,7 +1,8 @@
 /**
  * Module dependencies.
  */
-var SessionStrategy = require('./strategies/session');
+var SessionStrategy = require('./strategies/session')
+  , SessionManager = require('./sessionmanager');
 
 
 /**
@@ -29,6 +30,7 @@ function Authenticator() {
 Authenticator.prototype.init = function() {
   this.framework(require('./framework/connect')());
   this.use(new SessionStrategy());
+  this._sm = new SessionManager({ key: this._key }, this.serializeUser.bind(this));
 };
 
 /**
@@ -230,6 +232,14 @@ Authenticator.prototype.authorize = function(strategy, options, callback) {
 Authenticator.prototype.session = function(options) {
   return this.authenticate('session', options);
 };
+
+// TODO: Make session manager pluggable
+/*
+Authenticator.prototype.sessionManager = function(mgr) {
+  this._sm = mgr;
+  return this;
+}
+*/
 
 /**
  * Registers a function used to serialize user objects into the session.

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -29,7 +29,7 @@ function Authenticator() {
  */
 Authenticator.prototype.init = function() {
   this.framework(require('./framework/connect')());
-  this.use(new SessionStrategy({ key: this._key }, this.deserializeUser.bind(this)));
+  this.use(new SessionStrategy(this.deserializeUser.bind(this)));
   this._sm = new SessionManager({ key: this._key }, this.serializeUser.bind(this));
 };
 

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -47,16 +47,8 @@ req.logIn = function(user, options, done) {
     if (typeof done != 'function') { throw new Error('req#login requires a callback function'); }
     
     var self = this;
-    this._passport.instance.serializeUser(user, this, function(err, obj) {
+    this._passport.instance._sm.logIn(this, user, function(err) {
       if (err) { self[property] = null; return done(err); }
-      if (!self._passport.session) {
-        self._passport.session = {};
-      }
-      self._passport.session.user = obj;
-      if (!self.session) {
-        self.session = {};
-      }
-      self.session[self._passport.instance._key] = self._passport.session;
       done();
     });
   } else {

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -69,8 +69,8 @@ req.logOut = function() {
   }
   
   this[property] = null;
-  if (this._passport && this._passport.session) {
-    delete this._passport.session.user;
+  if (this._passport) {
+    this._passport.instance._sm.logOut(this);
   }
 };
 

--- a/lib/sessionmanager.js
+++ b/lib/sessionmanager.js
@@ -1,0 +1,32 @@
+function SessionManager(options, serializeUser) {
+  if (typeof options == 'function') {
+    serializeUser = options;
+    options = undefined;
+  }
+  options = options || {};
+  
+  this._key = options.key || 'passport';
+  this._serializeUser = serializeUser;
+}
+
+SessionManager.prototype.logIn = function(req, user, cb) {
+  var self = this;
+  this._serializeUser(user, req, function(err, obj) {
+    if (err) {
+      return cb(err);
+    }
+    if (!req._passport.session) {
+      req._passport.session = {};
+    }
+    req._passport.session.user = obj;
+    if (!req.session) {
+      req.session = {};
+    }
+    // TODO: Remove instance access, in favor of _key option
+    req.session[req._passport.instance._key] = req._passport.session;
+    cb();
+  });
+}
+
+
+module.exports = SessionManager;

--- a/lib/sessionmanager.js
+++ b/lib/sessionmanager.js
@@ -22,8 +22,7 @@ SessionManager.prototype.logIn = function(req, user, cb) {
     if (!req.session) {
       req.session = {};
     }
-    // TODO: Remove instance access, in favor of _key option
-    req.session[req._passport.instance._key] = req._passport.session;
+    req.session[self._key] = req._passport.session;
     cb();
   });
 }

--- a/lib/sessionmanager.js
+++ b/lib/sessionmanager.js
@@ -28,5 +28,12 @@ SessionManager.prototype.logIn = function(req, user, cb) {
   });
 }
 
+SessionManager.prototype.logOut = function(req, cb) {
+  if (req._passport && req._passport.session) {
+    delete req._passport.session.user;
+  }
+  cb && cb();
+}
+
 
 module.exports = SessionManager;

--- a/lib/strategies/session.js
+++ b/lib/strategies/session.js
@@ -11,9 +11,16 @@ var pause = require('pause')
  *
  * @api public
  */
-function SessionStrategy() {
+function SessionStrategy(options, deserializeUser) {
+  if (typeof options == 'function') {
+    deserializeUser = options;
+    options = undefined;
+  }
+  options = options || {};
+  
   Strategy.call(this);
   this.name = 'session';
+  this._deserializeUser = deserializeUser;
 }
 
 /**
@@ -50,11 +57,12 @@ SessionStrategy.prototype.authenticate = function(req, options) {
     //       matter, refer to: https://github.com/jaredhanson/passport/pull/106
     
     var paused = options.pauseStream ? pause(req) : null;
-    req._passport.instance.deserializeUser(su, req, function(err, user) {
+    this._deserializeUser(su, req, function(err, user) {
       if (err) { return self.error(err); }
       if (!user) {
         delete req._passport.session.user;
       } else {
+        // TODO: Remove instance access, in favor of _key option
         var property = req._passport.instance._userProperty || 'user';
         req[property] = user;
       }

--- a/lib/strategies/session.js
+++ b/lib/strategies/session.js
@@ -62,7 +62,7 @@ SessionStrategy.prototype.authenticate = function(req, options) {
       if (!user) {
         delete req._passport.session.user;
       } else {
-        // TODO: Remove instance access, in favor of _key option
+        // TODO: Remove instance access
         var property = req._passport.instance._userProperty || 'user';
         req[property] = user;
       }

--- a/test/authenticator.middleware.test.js
+++ b/test/authenticator.middleware.test.js
@@ -220,6 +220,9 @@ describe('Authenticator', function() {
     
     describe('handling a request', function() {
       var passport = new Authenticator();
+      passport.deserializeUser(function(user, done) {
+        done(null, { id: user });
+      });
     
       var request, error;
 
@@ -230,9 +233,6 @@ describe('Authenticator', function() {
             
             req._passport = {};
             req._passport.instance = {};
-            req._passport.instance.deserializeUser = function(user, req, done) {
-              done(null, { id: user });
-            };
             req._passport.session = {};
             req._passport.session.user = '123456';
           })

--- a/test/strategies/session.pause.test.js
+++ b/test/strategies/session.pause.test.js
@@ -16,7 +16,9 @@ describe('SessionStrategy', function() {
     
     
     var SessionStrategy = $require('../../lib/strategies/session', { pause: pause });
-    var strategy = new SessionStrategy();
+    var strategy = new SessionStrategy(function(user, req, done) {
+      done(null, { id: user });
+    });
     
     var request, pass = false;
   
@@ -31,9 +33,6 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.instance.deserializeUser = function(user, req, done) {
-            done(null, { id: user });
-          };
           req._passport.session = {};
           req._passport.session.user = '123456';
         })
@@ -79,7 +78,9 @@ describe('SessionStrategy', function() {
     
     
     var SessionStrategy = $require('../../lib/strategies/session', { pause: pause });
-    var strategy = new SessionStrategy();
+    var strategy = new SessionStrategy(function(user, req, done) {
+      done(null, false);
+    });
     
     var request, pass = false;
   
@@ -94,9 +95,6 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.instance.deserializeUser = function(user, req, done) {
-            done(null, false);
-          };
           req._passport.session = {};
           req._passport.session.user = '123456';
         })

--- a/test/strategies/session.test.js
+++ b/test/strategies/session.test.js
@@ -41,6 +41,10 @@ describe('SessionStrategy', function() {
   });
   
   describe('handling a request with a login session', function() {
+    var strategy = new SessionStrategy(function(user, req, done) {
+      done(null, { id: user });
+    });
+    
     var request, pass = false;
   
     before(function(done) {
@@ -54,9 +58,6 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.instance.deserializeUser = function(user, req, done) {
-            done(null, { id: user });
-          };
           req._passport.session = {};
           req._passport.session.user = '123456';
         })
@@ -79,6 +80,10 @@ describe('SessionStrategy', function() {
   });
   
   describe('handling a request with a login session serialized to 0', function() {
+    var strategy = new SessionStrategy(function(user, req, done) {
+      done(null, { id: user });
+    });
+    
     var request, pass = false;
   
     before(function(done) {
@@ -92,9 +97,6 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.instance.deserializeUser = function(user, req, done) {
-            done(null, { id: user });
-          };
           req._passport.session = {};
           req._passport.session.user = 0;
         })
@@ -117,6 +119,10 @@ describe('SessionStrategy', function() {
   });
   
   describe('handling a request with a login session that has been invalidated', function() {
+    var strategy = new SessionStrategy(function(user, req, done) {
+      done(null, false);
+    });
+    
     var request, pass = false;
   
     before(function(done) {
@@ -130,9 +136,6 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.instance.deserializeUser = function(user, req, done) {
-            done(null, false);
-          };
           req._passport.session = {};
           req._passport.session.user = '123456';
         })
@@ -154,6 +157,10 @@ describe('SessionStrategy', function() {
   });
   
   describe('handling a request with a login session and setting custom user property', function() {
+    var strategy = new SessionStrategy(function(user, req, done) {
+      done(null, { id: user });
+    });
+    
     var request, pass = false;
   
     before(function(done) {
@@ -168,9 +175,6 @@ describe('SessionStrategy', function() {
           req._passport = {};
           req._passport.instance = {};
           req._passport.instance._userProperty = 'currentUser';
-          req._passport.instance.deserializeUser = function(user, req, done) {
-            done(null, { id: user });
-          };
           req._passport.session = {};
           req._passport.session.user = '123456';
         })
@@ -192,6 +196,10 @@ describe('SessionStrategy', function() {
   });
   
   describe('handling a request with a login session that encounters an error when deserializing', function() {
+    var strategy = new SessionStrategy(function(user, req, done) {
+      done(new Error('something went wrong'));
+    });
+    
     var request, error;
   
     before(function(done) {
@@ -205,9 +213,6 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.instance.deserializeUser = function(user, req, done) {
-            done(new Error('something went wrong'));
-          };
           req._passport.session = {};
           req._passport.session.user = '123456';
         })


### PR DESCRIPTION
This PR is the first step in refactoring session access into a session manager.  Eventually, the session manager will be pluggable, so that implementation can choose to override session management.

The only API impacted by this PR is the SessionStrategy constructor, which now requires a `deserializeUser` function.  Because the SessionStrategy is instantiated internally by passport, it is unlikely that this will cause any compatibility issues.  If an application were, for some reason, constructing the SessionStrategy outside of passport, then this argument will need to be passed.