### PR TITLE
[WIP] Dynamic Configuration 

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -165,6 +165,12 @@ Authenticator.prototype.authenticate = function(strategy, options, callback) {
   return this._framework.authenticate(this, strategy, options, callback);
 };
 
+
+Authenticator.prototype.authenticateWith = function(strategy, options, callback) {
+  return this._framework.authenticateWith(this, strategy, options, callback);
+};
+
+
 /**
  * Middleware that will authorize a third-party account using the given
  * `strategy` name, with optional `options`.

--- a/lib/framework/connect.js
+++ b/lib/framework/connect.js
@@ -2,7 +2,8 @@
  * Module dependencies.
  */
 var initialize = require('../middleware/initialize')
-  , authenticate = require('../middleware/authenticate');
+  , authenticate = require('../middleware/authenticate')
+  , authenticateWith = require('../middleware/authenticateWith');
   
 /**
  * Framework support for Connect/Express.
@@ -22,7 +23,8 @@ exports = module.exports = function() {
   
   return {
     initialize: initialize,
-    authenticate: authenticate
+    authenticate: authenticate,
+    authenticateWith: authenticateWith
   };
 };
 

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -2,8 +2,10 @@
  * Module dependencies.
  */
 var http = require('http')
+  , Strategy = require('passport-strategy')
   , IncomingMessageExt = require('../http/request')
   , AuthenticationError = require('../errors/authenticationerror');
+
 
 
 /**
@@ -61,13 +63,13 @@ var http = require('http')
  *
  *     passport.authenticate('twitter');
  *
- * @param {String|Array} name
+ * @param {Strategy|String|Array} method
  * @param {Object} options
  * @param {Function} callback
  * @return {Function}
  * @api public
  */
-module.exports = function authenticate(passport, name, options, callback) {
+module.exports = function authenticate(passport, method, options, callback) {
   if (typeof options == 'function') {
     callback = options;
     options = {};
@@ -76,18 +78,18 @@ module.exports = function authenticate(passport, name, options, callback) {
   
   var multi = true;
   
-  // Cast `name` to an array, allowing authentication to pass through a chain of
-  // strategies.  The first strategy to succeed, redirect, or error will halt
-  // the chain.  Authentication failures will proceed through each strategy in
-  // series, ultimately failing if all strategies fail.
+  // Cast `method` to an array, allowing authentication to pass through a
+  // chain of strategies.  The first strategy to succeed, redirect, or error
+  // will halt the chain.  Authentication failures will proceed through each
+  // strategy in series, ultimately failing if all strategies fail.
   //
   // This is typically used on API endpoints to allow clients to authenticate
   // using their preferred choice of Basic, Digest, token-based schemes, etc.
   // It is not feasible to construct a chain of multiple strategies that involve
   // redirection (for example both Facebook and Twitter), since the first one to
   // redirect will halt the chain.
-  if (!Array.isArray(name)) {
-    name = [ name ];
+  if (!Array.isArray(method)) {
+    method = [ method ];
     multi = false;
   }
   
@@ -175,18 +177,17 @@ module.exports = function authenticate(passport, name, options, callback) {
     }
     
     (function attempt(i) {
-      var layer = name[i];
+      var layer = method[i];
       // If no more strategies exist in the chain, authentication has failed.
       if (!layer) { return allFailed(); }
     
       // Get the strategy, which will be used as prototype from which to create
       // a new instance.  Action functions will then be bound to the strategy
       // within the context of the HTTP request/response pair.
-      var prototype = passport._strategy(layer);
+      var prototype = (layer instanceof Strategy) ? layer : passport._strategy(layer);
       if (!prototype) { return next(new Error('Unknown authentication strategy "' + layer + '"')); }
-    
+
       var strategy = Object.create(prototype);
-      
       
       // ----- BEGIN STRATEGY AUGMENTATION -----
       // Augment the new strategy instance with action functions.  These action

--- a/lib/middleware/authenticateWith.js
+++ b/lib/middleware/authenticateWith.js
@@ -1,0 +1,39 @@
+/**
+ * Module dependencies.
+ */
+var authenticate = require('./authenticate')
+  , Strategy = require('passport-strategy')
+
+
+module.exports = function authenticateWith(passport, configurator, options, callback) {
+  if (typeof options == 'function') {
+    callback = options;
+    options = {};
+  }
+  options = options || {};
+
+  if (!configurator) { throw new TypeError('passport.authenticateWith middleware requires a configuration function'); }
+
+  return function authenticateWith(req, res, next) {
+
+    function configured(err, method) {
+      if (err) { return next(err); }
+      if (!method) {
+        return next(new Error('Dynamic configuration did not return a valid passport strategy'));
+      }
+
+      return authenticate(passport, method, options, callback)(req, res, next);
+    }
+
+    try {
+      var arity = configurator.length;
+      if (arity == 3) {
+        configurator(req, options, configured);
+      } else { // arity == 2
+        configurator(req, configured);
+      }
+    } catch (ex) {
+      return next(ex);
+    }
+  };
+};


### PR DESCRIPTION
This is a work in progress sketch of dynamic configuration of passport strategies, to get high-level feedback from @jaredhanson on the design before committing to writing tests and adding comments.

Two changes are made, first, the standard `authenticate` middleware is altered so that it may be called with an instance of the [`Strategy` class or subclass](https://github.com/jaredhanson/passport-strategy/blob/master/lib/strategy.js). So you could write middleware like:

```js
app.post('/login', 
  function authWrap(req, res, next) {
    var lstrategy = new LocalStrategy(function(username, password, done) {
      var db = dbs[req.params.directory];
      db.users.verify(username, password, function(err, user) {
        if (err) { return next(err); }
        if (!user) { return done(null, false); }
        return done(null, user);
      });
    }

    return passport.authenticate(lstrategy)(req, res, next);
  },
  function(req, res) {
    res.redirect('/');
  });
```

The second change is the introduction of an `authenticateWith` middleware, that acts as syntactic sugar for the above approach. With it, you can use a cleaner model like:


```js
function lsConfig(req, done) {
  var lstrategy = new LocalStrategy(function(username, password, done) {
    var db = dbs[req.params.directory];
    db.users.verify(username, password, function(err, user) {
      if (err) { return next(err); }
      if (!user) { return done(null, false); }
      return done(null, user);
    });

  return done(null, lstrategy);
}

app.post('/login', 
  passport.authenticateWith(lsConfig),
  function(req, res) {
    res.redirect('/');
  });
```

The new configurator callback can be of either of the following definitions:

```js
function configurator(req, options, done) {};
function configurator(req, done) {};
```

It can also return a string or array of strings to use strategies loaded with `passport.use`, e.g. if you dynamically want to limit the valid strategies on a route.