### PR TITLE
Link to ooth, a user accounts library built on top of passport.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ that uses [passport-local](https://github.com/jaredhanson/passport-local).
 
 ## Related Modules
 
+- [Ooth](https://github.com/nmaro/ooth) - User accounts library built on top of passport.js
 - [Locomotive](https://github.com/jaredhanson/locomotive) — Powerful MVC web framework
 - [OAuthorize](https://github.com/jaredhanson/oauthorize) — OAuth service provider toolkit
 - [OAuth2orize](https://github.com/jaredhanson/oauth2orize) — OAuth 2.0 authorization server toolkit


### PR DESCRIPTION
Passport.js is a great solution for authentication for node.js. A concern that passport.js delegates to its users is what to do with the received credentials (e.g. emails, usernames, passwords). Usually people solve this by copying some snippets of code online. But this  isn't a trivial issue. Apart from the inefficiency of people reimplementing the same thing and from security risks such as storing passwords in plain text, there are many tricky user account flow details that people usually don't think about such as logging in with different strategies (what if I log in with facebook with an email that I already used to log in with a local strategy?). These are the things solved by [ooth](https://github.com/nmaro/ooth). Ooth, just like passport.js, is modular and builds on top of passport.js strategies. With 144 commits since February it moved out of alpha today to 1.0. In this pull request I link Ooth as a linked library. I believe it will solve many people a headache.