### PR TITLE
Update link to Postgres integration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ that uses [passport-local](https://github.com/jaredhanson/passport-local).
       - Express v3x - [Tutorial](http://mherman.org/blog/2016/09/25/node-passport-and-postgres/#.V-govpMrJE5) / [working example](https://github.com/mjhea0/passport-local-knex)
       - Express v4x - [Tutorial](http://mherman.org/blog/2015/01/31/local-authentication-with-passport-and-express-4/) / [working example](https://github.com/mjhea0/passport-local-express4)
     - Postgres
-      - [Tutorial](http://mherman.org/blog/2015/01/31/local-authentication-with-passport-and-express-4/) / [working example](https://github.com/mjhea0/passport-local-express4)
+      - [Tutorial](http://mherman.org/blog/2016/09/25/node-passport-and-postgres/) / [working example](https://github.com/mjhea0/passport-local-knex)
 - **Social Authentication**: Refer to the following tutorials for setting up various social authentication strategies:
     - Express v3x - [Tutorial](http://mherman.org/blog/2013/11/10/social-authentication-with-passport-dot-js/) / [working example](https://github.com/mjhea0/passport-examples)
     - Express v4x - [Tutorial](http://mherman.org/blog/2015/09/26/social-authentication-in-node-dot-js-with-passport) / [working example](https://github.com/mjhea0/passport-social-auth)


### PR DESCRIPTION
The link to the tutorial and code repo to use postgres were pointing to the Mongo examples. I found the actual links and updated the urls so people wont be as confused as I was.