### PR TITLE
check for empty success and failure redirect in authenticate.js

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -141,7 +141,7 @@ module.exports = function authenticate(passport, name, options, callback) {
           req.session.messages.push(msg);
         }
       }
-      if (options.failureRedirect) {
+      if (options.failureRedirect !== '') {
         return res.redirect(options.failureRedirect);
       }
     
@@ -257,7 +257,7 @@ module.exports = function authenticate(passport, name, options, callback) {
               }
               return res.redirect(url);
             }
-            if (options.successRedirect) {
+            if (options.successRedirect !== '') {
               return res.redirect(options.successRedirect);
             }
             next();


### PR DESCRIPTION
check for empty success and failure redirect in authenticate.js so that passport.authenticate can call next() if we pass successRedirect or failureRedirect as an empty string.