### PR TITLE
Fix premature redirect when used with express-session

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -101,6 +101,15 @@ module.exports = function authenticate(passport, name, options, callback) {
     // accumulator for failures from each strategy in the chain
     var failures = [];
     
+    function redirect(url) {
+      if (req.session && req.session.save && typeof req.session.save == 'function') {
+        return req.session.save(function() {
+          return res.redirect(url);
+        });
+      }
+      return res.redirect(url);
+    }
+    
     function allFailed() {
       if (callback) {
         if (!multi) {
@@ -142,7 +151,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         }
       }
       if (options.failureRedirect) {
-        return res.redirect(options.failureRedirect);
+        return redirect(options.failureRedirect);
       }
     
       // When failure handling is not delegated to the application, the default
@@ -255,10 +264,10 @@ module.exports = function authenticate(passport, name, options, callback) {
                 url = req.session.returnTo;
                 delete req.session.returnTo;
               }
-              return res.redirect(url);
+              return redirect(url);
             }
             if (options.successRedirect) {
-              return res.redirect(options.successRedirect);
+              return redirect(options.successRedirect);
             }
             next();
           }


### PR DESCRIPTION
#### Are you implementing a new feature?
I'm not sure if you will call this "a new feature", it will solve a lot of issues involving `express-session` not saving the session in time before redirects happen, by calling `req.session.save()`.

#### Is this a security patch?
No

<!-- Provide a detailed description of your use case, including as much -->
<!-- detail as possible about what you are trying to accomplish and why. -->
<!-- If this patch closes an open issue, include a reference to the issue -->
<!-- number. -->
# Detail
By calling `req.session.save()` before `res.redirect()`, it ensures the session is properly stored in the session store, avoiding issues like #306, #401, #477, #482 (and possibly #254, #314, #521). To ensure compatibility, the code will check `req.session.save && typeof req.session.save == 'function'` before calling `req.session.save()`. Reference: expressjs/session#74

### Note
As I only tested this with `express`, `express-session` and a specific session store for `express-session`, I'm not sure if this would cause issue with Connect or other middlewares. A more thorough test is probably required.

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [X] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
