### PR TITLE
Document `failWithError` parameter in authenticate()

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -29,6 +29,8 @@ var http = require('http')
  *                        message for failure.
  *   - `failureFlash`     True to flash failure messages or a string to use as a flash
  *                        message for failures (overrides any from the strategy itself).
+ *   - `failWithError`    True to pass off the error onto the next Express handler in
+ *                        the form of an `AuthenticationError`
  *   - `assignProperty`   Assign the object provided by the verify callback to given property
  *
  * An optional `callback` can be supplied to allow the application to override


### PR DESCRIPTION
Helps with #458. I don't know where to submit a change that would update http://www.passportjs.org/docs/authenticate/ but I'd be happy to help with that too

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
