### PR TITLE
Fix postgres tutorial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ that uses [passport-local](https://github.com/jaredhanson/passport-local).
       - Express v3x - [Tutorial](http://mherman.org/blog/2016/09/25/node-passport-and-postgres/#.V-govpMrJE5) / [working example](https://github.com/mjhea0/passport-local-knex)
       - Express v4x - [Tutorial](http://mherman.org/blog/2015/01/31/local-authentication-with-passport-and-express-4/) / [working example](https://github.com/mjhea0/passport-local-express4)
     - Postgres
-      - [Tutorial](http://mherman.org/blog/2015/01/31/local-authentication-with-passport-and-express-4/) / [working example](https://github.com/mjhea0/passport-local-express4)
+      - [Tutorial](https://mherman.org/blog/node-passport-and-postgres/) / [working example](https://github.com/mjhea0/passport-local-express4)
 - **Social Authentication**: Refer to the following tutorials for setting up various social authentication strategies:
     - Express v3x - [Tutorial](http://mherman.org/blog/2013/11/10/social-authentication-with-passport-dot-js/) / [working example](https://github.com/mjhea0/passport-examples)
     - Express v4x - [Tutorial](http://mherman.org/blog/2015/09/26/social-authentication-in-node-dot-js-with-passport) / [working example](https://github.com/mjhea0/passport-social-auth)


### PR DESCRIPTION
The current url for the postgres tutorial is related to mongo