### PR TITLE
feat: ability to pass strategy object to authenticate

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -61,7 +61,7 @@ var http = require('http')
  *
  *     passport.authenticate('twitter');
  *
- * @param {String|Array} name
+ * @param {String|Array|Object} name
  * @param {Object} options
  * @param {Function} callback
  * @return {Function}
@@ -182,7 +182,12 @@ module.exports = function authenticate(passport, name, options, callback) {
       // Get the strategy, which will be used as prototype from which to create
       // a new instance.  Action functions will then be bound to the strategy
       // within the context of the HTTP request/response pair.
-      var prototype = passport._strategy(layer);
+      var prototype ;
+      if( typeof layer === 'object'){
+        prototype = layer;
+      }else{
+        prototype = passport._strategy(layer);
+      }
       if (!prototype) { return next(new Error('Unknown authentication strategy "' + layer + '"')); }
     
       var strategy = Object.create(prototype);


### PR DESCRIPTION
Some would like to pass passport strategy dynamically inside request handlers. This provides better control over passport authorization. 

For example, look at example below for multi tenant applications:

```js
function loadTenantProviderSettings(req){
  // return settings
}

function generateProviderStrategy(provider, settings){
 // return strategy instance. ex:
 // new GoogleStrategy({ ...settings },
 //           (accessToken, refreshToken, profile, done) => {
 //             return done(null , profile);
 //           },
 //         ))
}


app.get('/socialLogin/:provider', function(req,res,next){
  const socialProvider = req.params.provider
  const settings = loadTenantProviderSettings(req);

  passport.authenticate(generateProviderStrategy(socialProvider, settings), async (err, user,info) => { })(req,res,next)
})
```