### PR TITLE
Validate next parameter to ensure it's a function

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -92,6 +92,9 @@ module.exports = function authenticate(passport, name, options, callback) {
   }
   
   return function authenticate(req, res, next) {
+    if (typeof next !== 'function') {
+      throw 'TypeError: next is not a function. authenticate function requires (req, res, next)';
+    }
     if (http.IncomingMessage.prototype.logIn
         && http.IncomingMessage.prototype.logIn !== IncomingMessageExt.logIn) {
       require('../framework/connect').__monkeypatchNode();


### PR DESCRIPTION
This checks that the next parameter is a function, and if it is not, throws a detailed error message.

I battled with a confusing error message from a line deep within the strategy file because I forgot to pass in the next parameter (I just passed in 'req, res'). An error message like the one I've added would have made it obvious what I'd done wrong. I'm hoping this might stop others who encounter this in the future.

Previously raised an issue here: https://github.com/jaredhanson/passport-oauth2/issues/124. 

### Checklist

- [x ] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [x ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
