### PR TITLE
Treat Strategy equal to name in passport.authenticate

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -184,15 +184,14 @@ module.exports = function authenticate(passport, name, options, callback) {
       // within the context of the HTTP request/response pair.
       var strategy, prototype;
       if (typeof layer.authenticate == 'function') {
-        strategy = layer;
+        prototype = layer;
       } else {
         prototype = passport._strategy(layer);
         if (!prototype) { return next(new Error('Unknown authentication strategy "' + layer + '"')); }
-        
-        strategy = Object.create(prototype);
       }
-      
-      
+      strategy = Object.create(prototype);
+
+
       // ----- BEGIN STRATEGY AUGMENTATION -----
       // Augment the new strategy instance with action functions.  These action
       // functions are bound via closure the the request/response pair.  The end

--- a/test/middleware/authenticate.success.concurrent.test.js
+++ b/test/middleware/authenticate.success.concurrent.test.js
@@ -1,0 +1,69 @@
+/* global describe, it, expect, before */
+/* jshint expr: true */
+
+var chai = require('chai')
+  , authenticate = require('../../lib/middleware/authenticate')
+  , Passport = require('../..').Passport;
+
+
+describe('middleware/authenticate', function () {
+
+  function Strategy() {
+    this.authentications = []
+  }
+  Strategy.prototype.authenticate = function (req) {
+    this.authentications.push({ self: this, req: req });
+    if (this.authentications.length === 2) {
+      for (var j = 0, len = this.authentications.length; j < len; j++) {
+        var auth = this.authentications[j];
+        auth.self.success(auth.req._user);
+      }
+    }
+  };
+
+  function testRun(passport, strategy) {
+    var request = []
+      , next = [];
+
+    before(function (done) {
+      function prepare(test) {
+        test
+          .req(function (req) {
+            request.push(req);
+            req._user = request.length;
+          })
+          .next(function () {
+            next.push(test);
+            if (next.length === 2) {
+              done();
+            }
+          })
+          .dispatch();
+      };
+
+      var middleware = authenticate(passport, strategy, { assignProperty: 'user' });
+      prepare(chai.connect.use(middleware));
+      prepare(chai.connect.use(middleware));
+    });
+
+    it('should complete different requests', function () {
+      expect(next[0]).to.not.equal(next[1]);
+    })
+    it('should assign correct user to correct request', function () {
+      expect(request[0].user).to.equal(request[0]._user);
+      expect(request[1].user).to.equal(request[1]._user);
+    })
+  }
+
+  describe('success two requests concurrently by name', function () {
+    var passport = new Passport();
+    passport.use('success', new Strategy());
+    testRun(passport, 'success');
+  });
+
+  describe('success two requests concurrently by instance', function () {
+    var passport = new Passport();
+    testRun(passport, new Strategy());
+  });
+
+});


### PR DESCRIPTION
The passport.authenticate jsdoc says it can take "_@param {Strategy|String|Array} name_". I passed in the Strategy to avoid figuring out a unique name for strategy instantiated dynamically from configuration. But then the authentication failed concurrent requests.

When passed a Strategy, passport.authenticate does not make a new object per request causing strategy augmentation on the strategy itself rather than per request object. When there are many concurrent requests shared augmentation makes all concurrent requests call same next callback.

Fixes: 380b5c87d028f8bf65ae35c75b2a306e65efd9bb ("Stylistic edits.")

It seems passing strategy used to be treated the same as name before the Stylistic edits. So it seems the change was not intended.

I'm not experienced mocha&chai writer, but the attached test case demonstrates the problem.

Linting indicated errors on lines not touched by this pull request.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
