### PR TITLE
Add fastify compatibility

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -324,10 +324,23 @@ module.exports = function authenticate(passport, name, options, callback) {
         //         - all versions (as of 4.8.7) continue to accept res.redirect(url, status)
         //           but issue deprecated versions
         
-        res.statusCode = status || 302;
-        res.setHeader('Location', url);
-        res.setHeader('Content-Length', '0');
-        res.end();
+        var defaultRedirect = 302;
+        var headerLocationKey = 'Location'
+        var headerContentLengthKey = 'Content-Length'
+        
+        if(res.req) {
+          // Express
+          res.statusCode = status || defaultRedirect;
+          res.setHeader(headerLocationKey, url);
+          res.setHeader(headerContentLengthKey, '0');
+          res.end();
+        } else {
+          // Fastify
+          res.statusCode = status || defaultRedirect;
+          res.header(headerLocationKey, url);
+          res.header(headerContentLengthKey, '0');
+          res.send();
+        }
       };
       
       /**


### PR DESCRIPTION
When we use this lib with a Fastify response we get an error because in this case the methods setHeaders and end doesn't exists