### PR TITLE
No monkeypatch

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -29,7 +29,7 @@ function Authenticator() {
  */
 Authenticator.prototype.init = function() {
   this.framework(require('./framework/connect')());
-  this.use(new SessionStrategy(this.deserializeUser.bind(this)));
+  this.use(new SessionStrategy({ key: this._key }, this.deserializeUser.bind(this)));
   this._sm = new SessionManager({ key: this._key }, this.serializeUser.bind(this));
 };
 

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -17,7 +17,6 @@ function Authenticator() {
   this._deserializers = [];
   this._infoTransformers = [];
   this._framework = null;
-  this._userProperty = 'user';
   
   this.init();
 }
@@ -128,8 +127,6 @@ Authenticator.prototype.framework = function(fw) {
  */
 Authenticator.prototype.initialize = function(options) {
   options = options || {};
-  this._userProperty = options.userProperty || 'user';
-  
   return this._framework.initialize(this, options);
 };
 

--- a/lib/framework/connect.js
+++ b/lib/framework/connect.js
@@ -8,32 +8,15 @@ var initialize = require('../middleware/initialize')
  * Framework support for Connect/Express.
  *
  * This module provides support for using Passport with Express.  It exposes
- * middleware that conform to the `fn(req, res, next)` signature and extends
- * Node's built-in HTTP request object with useful authentication-related
- * functions.
+ * middleware that conform to the `fn(req, res, next)` signature.
  *
  * @return {Object}
  * @api protected
  */
 exports = module.exports = function() {
   
-  // HTTP extensions.
-  exports.__monkeypatchNode();
-  
   return {
     initialize: initialize,
     authenticate: authenticate
   };
-};
-
-exports.__monkeypatchNode = function() {
-  var http = require('http');
-  var IncomingMessageExt = require('../http/request');
-  
-  http.IncomingMessage.prototype.login =
-  http.IncomingMessage.prototype.logIn = IncomingMessageExt.logIn;
-  http.IncomingMessage.prototype.logout =
-  http.IncomingMessage.prototype.logOut = IncomingMessageExt.logOut;
-  http.IncomingMessage.prototype.isAuthenticated = IncomingMessageExt.isAuthenticated;
-  http.IncomingMessage.prototype.isUnauthenticated = IncomingMessageExt.isUnauthenticated;
 };

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -28,10 +28,7 @@ req.logIn = function(user, options, done) {
   }
   options = options || {};
   
-  var property = 'user';
-  if (this._passport && this._passport.instance) {
-    property = this._passport.instance._userProperty || 'user';
-  }
+  var property = this._userProperty || 'user';
   var session = (options.session === undefined) ? true : options.session;
   
   this[property] = user;
@@ -56,10 +53,7 @@ req.logIn = function(user, options, done) {
  */
 req.logout =
 req.logOut = function() {
-  var property = 'user';
-  if (this._passport && this._passport.instance) {
-    property = this._passport.instance._userProperty || 'user';
-  }
+  var property = this._userProperty || 'user';
   
   this[property] = null;
   if (this._passport) {
@@ -74,11 +68,7 @@ req.logOut = function() {
  * @api public
  */
 req.isAuthenticated = function() {
-  var property = 'user';
-  if (this._passport && this._passport.instance) {
-    property = this._passport.instance._userProperty || 'user';
-  }
-  
+  var property = this._userProperty || 'user';
   return (this[property]) ? true : false;
 };
 

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -1,10 +1,3 @@
-/**
- * Module dependencies.
- */
-//var http = require('http')
-//  , req = http.IncomingMessage.prototype;
-
-
 var req = exports = module.exports = {};
 
 /**

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -92,12 +92,6 @@ module.exports = function authenticate(passport, name, options, callback) {
   }
   
   return function authenticate(req, res, next) {
-    if (http.IncomingMessage.prototype.logIn
-        && http.IncomingMessage.prototype.logIn !== IncomingMessageExt.logIn) {
-      require('../framework/connect').__monkeypatchNode();
-    }
-    
-    
     // accumulator for failures from each strategy in the chain
     var failures = [];
     

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -45,7 +45,8 @@ var IncomingMessageExt = require('../http/request');
  * @return {Function}
  * @api public
  */
-module.exports = function initialize(passport) {
+module.exports = function initialize(passport, options) {
+  options = options || {};
   
   return function initialize(req, res, next) {
     req.login =
@@ -54,6 +55,10 @@ module.exports = function initialize(passport) {
     req.logOut = IncomingMessageExt.logOut;
     req.isAuthenticated = IncomingMessageExt.isAuthenticated;
     req.isUnauthenticated = IncomingMessageExt.isUnauthenticated;
+    
+    if (options.userProperty) {
+      req._userProperty = options.userProperty;
+    }
     
     req._passport = {};
     req._passport.instance = passport;

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -1,4 +1,10 @@
 /**
+ * Module dependencies.
+ */
+var IncomingMessageExt = require('../http/request');
+
+
+/**
  * Passport initialization.
  *
  * Intializes Passport for incoming requests, allowing authentication strategies
@@ -42,6 +48,13 @@
 module.exports = function initialize(passport) {
   
   return function initialize(req, res, next) {
+    req.login =
+    req.logIn = IncomingMessageExt.logIn;
+    req.logout =
+    req.logOut = IncomingMessageExt.logOut;
+    req.isAuthenticated = IncomingMessageExt.isAuthenticated;
+    req.isUnauthenticated = IncomingMessageExt.isUnauthenticated;
+    
     req._passport = {};
     req._passport.instance = passport;
 

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -58,11 +58,6 @@ module.exports = function initialize(passport) {
     req._passport = {};
     req._passport.instance = passport;
 
-    if (req.session && req.session[passport._key]) {
-      // load data from existing session
-      req._passport.session = req.session[passport._key];
-    }
-
     next();
   };
 };

--- a/lib/sessionmanager.js
+++ b/lib/sessionmanager.js
@@ -15,14 +15,14 @@ SessionManager.prototype.logIn = function(req, user, cb) {
     if (err) {
       return cb(err);
     }
-    if (!req._passport.session) {
-      req._passport.session = {};
-    }
-    req._passport.session.user = obj;
+    // TODO: Error if session isn't available here.
     if (!req.session) {
       req.session = {};
     }
-    req.session[self._key] = req._passport.session;
+    if (!req.session[self._key]) {
+      req.session[self._key] = {};
+    }
+    req.session[self._key].user = obj;
     cb();
   });
 }

--- a/lib/sessionmanager.js
+++ b/lib/sessionmanager.js
@@ -28,9 +28,10 @@ SessionManager.prototype.logIn = function(req, user, cb) {
 }
 
 SessionManager.prototype.logOut = function(req, cb) {
-  if (req._passport && req._passport.session) {
-    delete req._passport.session.user;
+  if (req.session && req.session[this._key]) {
+    delete req.session[this._key].user;
   }
+  
   cb && cb();
 }
 

--- a/lib/strategies/session.js
+++ b/lib/strategies/session.js
@@ -20,6 +20,7 @@ function SessionStrategy(options, deserializeUser) {
   
   Strategy.call(this);
   this.name = 'session';
+  this._key = options.key || 'passport';
   this._deserializeUser = deserializeUser;
 }
 
@@ -47,8 +48,8 @@ SessionStrategy.prototype.authenticate = function(req, options) {
 
   var self = this, 
       su;
-  if (req._passport.session) {
-    su = req._passport.session.user;
+  if (req.session[this._key]) {
+    su = req.session[this._key].user;
   }
 
   if (su || su === 0) {
@@ -60,7 +61,7 @@ SessionStrategy.prototype.authenticate = function(req, options) {
     this._deserializeUser(su, req, function(err, user) {
       if (err) { return self.error(err); }
       if (!user) {
-        delete req._passport.session.user;
+        delete req.session[self._key].user;
       } else {
         // TODO: Remove instance access
         var property = req._passport.instance._userProperty || 'user';

--- a/lib/strategies/session.js
+++ b/lib/strategies/session.js
@@ -63,8 +63,7 @@ SessionStrategy.prototype.authenticate = function(req, options) {
       if (!user) {
         delete req.session[self._key].user;
       } else {
-        // TODO: Remove instance access
-        var property = req._passport.instance._userProperty || 'user';
+        var property = req._userProperty || 'user';
         req[property] = user;
       }
       self.pass();

--- a/test/authenticator.middleware.test.js
+++ b/test/authenticator.middleware.test.js
@@ -48,10 +48,6 @@ describe('Authenticator', function() {
         expect(request._passport.instance).to.be.an.instanceOf(Authenticator);
         expect(request._passport.instance).to.equal(passport);
       });
-    
-      it('should not expose session storage on internal request property', function() {
-        expect(request._passport.session).to.be.undefined;
-      });
     });
     
     describe('handling a request with custom user property', function() {
@@ -87,10 +83,6 @@ describe('Authenticator', function() {
         expect(request._passport).to.be.an('object');
         expect(request._passport.instance).to.be.an.instanceOf(Authenticator);
         expect(request._passport.instance).to.equal(passport);
-      });
-    
-      it('should not expose session storage on internal request property', function() {
-        expect(request._passport.session).to.be.undefined;
       });
     });
     

--- a/test/authenticator.middleware.test.js
+++ b/test/authenticator.middleware.test.js
@@ -278,8 +278,9 @@ describe('Authenticator', function() {
             
             req._passport = {};
             req._passport.instance = {};
-            req._passport.session = {};
-            req._passport.session.user = '123456';
+            req.session = {};
+            req.session['passport'] = {};
+            req.session['passport'].user = '123456';
           })
           .next(function(err) {
             error = err;
@@ -298,8 +299,8 @@ describe('Authenticator', function() {
       });
       
       it('should maintain session', function() {
-        expect(request._passport.session).to.be.an('object');
-        expect(request._passport.session.user).to.equal('123456');
+        expect(request.session['passport']).to.be.an('object');
+        expect(request.session['passport'].user).to.equal('123456');
       });
     });
     

--- a/test/authenticator.middleware.test.js
+++ b/test/authenticator.middleware.test.js
@@ -35,8 +35,8 @@ describe('Authenticator', function() {
         expect(error).to.be.undefined;
       });
       
-      it('should set user property on authenticator', function() {
-        expect(passport._userProperty).to.equal('user');
+      it('should not set user property on request', function() {
+        expect(request._userProperty).to.be.undefined;
       });
     
       it('should not initialize namespace within session', function() {
@@ -71,8 +71,8 @@ describe('Authenticator', function() {
         expect(error).to.be.undefined;
       });
       
-      it('should set user property on authenticator', function() {
-        expect(passport._userProperty).to.equal('currentUser');
+      it('should set user property on request', function() {
+        expect(request._userProperty).to.equal('currentUser');
       });
     
       it('should not initialize namespace within session', function() {

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -198,7 +198,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
+      req.session = {};
       
       var error;
       
@@ -227,7 +227,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should serialize user', function() {
-        expect(req._passport.session.user).to.equal('1');
+        expect(req.session['passport'].user).to.equal('1');
       });
     });
     
@@ -244,7 +244,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
+      req.session = {};
       
       var error;
       
@@ -277,7 +277,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should serialize user', function() {
-        expect(req._passport.session.user).to.equal('1');
+        expect(req.session['passport'].user).to.equal('1');
       });
     });
     

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -373,8 +373,9 @@ describe('http.ServerRequest', function() {
       req.user = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
-      req._passport.session.user = '1';
+      req.session = {};
+      req.session['passport'] = {};
+      req.session['passport'].user = '1';
       
       req.logout();
       
@@ -388,7 +389,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should clear serialized user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req.session['passport'].user).to.be.undefined;
       });
     });
     
@@ -403,8 +404,9 @@ describe('http.ServerRequest', function() {
       req._passport = {};
       req._passport.instance = passport;
       req._passport.instance._userProperty = 'currentUser';
-      req._passport.session = {};
-      req._passport.session.user = '1';
+      req.session = {};
+      req.session['passport'] = {};
+      req.session['passport'].user = '1';
       
       req.logout();
       
@@ -418,7 +420,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should clear serialized user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req.session['passport'].user).to.be.undefined;
       });
     });
     

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -43,7 +43,8 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
+      req.session = {};
+      req.session['passport'] = {};
       
       var error;
       
@@ -72,7 +73,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req.session['passport'].user).to.be.undefined;
       });
     });
     
@@ -86,7 +87,8 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
+      req.session = {};
+      req.session['passport'] = {};
       
       var error;
       
@@ -119,7 +121,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req.session['passport'].user).to.be.undefined;
       });
     });
     
@@ -132,7 +134,8 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
+      req.session = {};
+      req.session['passport'] = {};
       
       var user = { id: '1', username: 'root' };
       req.login(user, { session: false });
@@ -149,7 +152,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req.session['passport'].user).to.be.undefined;
       });
     });
     
@@ -293,7 +296,8 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
+      req.session = {};
+      req.session['passport'] = {};
       
       var error;
       
@@ -321,7 +325,7 @@ describe('http.ServerRequest', function() {
       });
       
       it('should not serialize user', function() {
-        expect(req._passport.session.user).to.be.undefined;
+        expect(req.session['passport'].user).to.be.undefined;
       });
     });
     
@@ -347,7 +351,8 @@ describe('http.ServerRequest', function() {
       req.login = request.login;
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.session = {};
+      req.session = {};
+      req.session['passport'] = {};
       
       var user = { id: '1', username: 'root' };
       

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -1,14 +1,14 @@
 /* global describe, it, expect, before */
 /* jshint expr: true */
 
-var http = require('http')
+var request = require('../../lib/http/request')
   , Passport = require('../..').Passport;
-
-require('../../lib/framework/connect').__monkeypatchNode();
 
 
 describe('http.ServerRequest', function() {
   
+  // TODO: Test that these are extended by initialize/authenticate
+  /*
   describe('prototoype', function() {
     var req = new http.IncomingMessage();
     
@@ -30,13 +30,17 @@ describe('http.ServerRequest', function() {
       expect(req.isUnauthenticated).to.be.an('function');
     });
   });
+  */
   
   describe('#login', function() {
     
     describe('not establishing a session', function() {
       var passport = new Passport();
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
@@ -76,7 +80,10 @@ describe('http.ServerRequest', function() {
       var passport = new Passport();
       passport._userProperty = 'currentUser';
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
@@ -119,7 +126,10 @@ describe('http.ServerRequest', function() {
     describe('not establishing a session and invoked without a callback', function() {
       var passport = new Passport();
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
@@ -144,7 +154,10 @@ describe('http.ServerRequest', function() {
     });
     
     describe('not establishing a session, without passport.initialize() middleware', function() {
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       
       var error;
       
@@ -179,7 +192,10 @@ describe('http.ServerRequest', function() {
         done(null, user.id);
       });
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
@@ -222,7 +238,10 @@ describe('http.ServerRequest', function() {
       });
       passport._userProperty = 'currentUser';
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
@@ -268,7 +287,10 @@ describe('http.ServerRequest', function() {
         done(new Error('something went wrong'));
       });
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
@@ -304,7 +326,8 @@ describe('http.ServerRequest', function() {
     });
     
     describe('establishing a session, without passport.initialize() middleware', function() {
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
       var user = { id: '1', username: 'root' };
       
       it('should throw an exception', function() {
@@ -320,7 +343,8 @@ describe('http.ServerRequest', function() {
         done(null, user.id);
       });
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.login = request.login;
       req._passport = {};
       req._passport.instance = passport;
       req._passport.session = {};
@@ -342,7 +366,10 @@ describe('http.ServerRequest', function() {
     describe('existing session', function() {
       var passport = new Passport();
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.logout = request.logout;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req.user = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = passport;
@@ -368,7 +395,10 @@ describe('http.ServerRequest', function() {
     describe('existing session and clearing custom user property', function() {
       var passport = new Passport();
       
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.logout = request.logout;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req.currentUser = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = passport;
@@ -393,7 +423,10 @@ describe('http.ServerRequest', function() {
     });
     
     describe('existing session, without passport.initialize() middleware', function() {
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.logout = request.logout;
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req.user = { id: '1', username: 'root' };
       
       req.logout();
@@ -414,7 +447,9 @@ describe('http.ServerRequest', function() {
   describe('#isAuthenticated', function() {
     
     describe('with a user', function() {
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req.user = { id: '1', username: 'root' };
       
       it('should be authenticated', function() {
@@ -424,7 +459,9 @@ describe('http.ServerRequest', function() {
     });
     
     describe('with a user set on custom property', function() {
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req.currentUser = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = {};
@@ -437,7 +474,9 @@ describe('http.ServerRequest', function() {
     });
     
     describe('without a user', function() {
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       
       it('should not be authenticated', function() {
         expect(req.isAuthenticated()).to.be.false;
@@ -446,7 +485,9 @@ describe('http.ServerRequest', function() {
     });
     
     describe('with a null user', function() {
-      var req = new http.IncomingMessage();
+      var req = new Object();
+      req.isAuthenticated = request.isAuthenticated;
+      req.isUnauthenticated = request.isUnauthenticated;
       req.user = null;
       
       it('should not be authenticated', function() {

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -79,7 +79,6 @@ describe('http.ServerRequest', function() {
     
     describe('not establishing a session and setting custom user property', function() {
       var passport = new Passport();
-      passport._userProperty = 'currentUser';
       
       var req = new Object();
       req.login = request.login;
@@ -89,6 +88,7 @@ describe('http.ServerRequest', function() {
       req._passport.instance = passport;
       req.session = {};
       req.session['passport'] = {};
+      req._userProperty = 'currentUser';
       
       var error;
       
@@ -239,7 +239,6 @@ describe('http.ServerRequest', function() {
       passport.serializeUser(function(user, done) {
         done(null, user.id);
       });
-      passport._userProperty = 'currentUser';
       
       var req = new Object();
       req.login = request.login;
@@ -248,6 +247,7 @@ describe('http.ServerRequest', function() {
       req._passport = {};
       req._passport.instance = passport;
       req.session = {};
+      req._userProperty = 'currentUser';
       
       var error;
       
@@ -408,7 +408,7 @@ describe('http.ServerRequest', function() {
       req.currentUser = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = passport;
-      req._passport.instance._userProperty = 'currentUser';
+      req._userProperty = 'currentUser';
       req.session = {};
       req.session['passport'] = {};
       req.session['passport'].user = '1';
@@ -472,7 +472,7 @@ describe('http.ServerRequest', function() {
       req.currentUser = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = {};
-      req._passport.instance._userProperty = 'currentUser';
+      req._userProperty = 'currentUser';
       
       it('should be authenticated', function() {
         expect(req.isAuthenticated()).to.be.true;

--- a/test/middleware/initialize.test.js
+++ b/test/middleware/initialize.test.js
@@ -37,10 +37,6 @@ describe('middleware/initialize', function() {
       expect(request._passport.instance).to.be.an.instanceOf(Passport);
       expect(request._passport.instance).to.equal(passport);
     });
-    
-    it('should not expose empty object as session storage on internal request property', function() {
-      expect(request._passport.session).to.be.undefined;
-    });
   });
   
   describe('handling a request with a new session', function() {
@@ -73,10 +69,6 @@ describe('middleware/initialize', function() {
       expect(request._passport).to.be.an('object');
       expect(request._passport.instance).to.be.an.instanceOf(Passport);
       expect(request._passport.instance).to.equal(passport);
-    });
-    
-    it('should not expose session storage on internal request property', function() {
-      expect(request._passport.session).to.be.undefined;
     });
   });
   
@@ -115,12 +107,6 @@ describe('middleware/initialize', function() {
       expect(request._passport.instance).to.be.an.instanceOf(Passport);
       expect(request._passport.instance).to.equal(passport);
     });
-    
-    it('should expose session storage on internal request property', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(Object.keys(request._passport.session)).to.have.length(1);
-      expect(request._passport.session.user).to.equal('123456');
-    });
   });
   
   describe('handling a request with an existing session using custom session key', function() {
@@ -158,12 +144,6 @@ describe('middleware/initialize', function() {
       expect(request._passport).to.be.an('object');
       expect(request._passport.instance).to.be.an.instanceOf(Passport);
       expect(request._passport.instance).to.equal(passport);
-    });
-    
-    it('should expose session storage on internal request property', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(Object.keys(request._passport.session)).to.have.length(1);
-      expect(request._passport.session.user).to.equal('123456');
     });
   });
   

--- a/test/strategies/session.pause.test.js
+++ b/test/strategies/session.pause.test.js
@@ -33,8 +33,9 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.session = {};
-          req._passport.session.user = '123456';
+          req.session = {};
+          req.session['passport'] = {};
+          req.session['passport'].user = '123456';
         })
         .authenticate({ pauseStream: true });
     });
@@ -53,8 +54,8 @@ describe('SessionStrategy', function() {
     });
     
     it('should maintain session', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(request._passport.session.user).to.equal('123456');
+      expect(request.session['passport']).to.be.an('object');
+      expect(request.session['passport'].user).to.equal('123456');
     });
     
     it('should pause request', function() {
@@ -95,8 +96,9 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.session = {};
-          req._passport.session.user = '123456';
+          req.session = {};
+          req.session['passport'] = {};
+          req.session['passport'].user = '123456';
         })
         .authenticate({ pauseStream: true });
     });
@@ -114,8 +116,8 @@ describe('SessionStrategy', function() {
     });
     
     it('should remove user from session', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(request._passport.session.user).to.be.undefined;
+      expect(request.session['passport']).to.be.an('object');
+      expect(request.session['passport'].user).to.be.undefined;
     });
     
     it('should pause request', function() {

--- a/test/strategies/session.test.js
+++ b/test/strategies/session.test.js
@@ -26,7 +26,8 @@ describe('SessionStrategy', function() {
           request = req;
           
           req._passport = {};
-          req._passport.session = {};
+          req.session = {};
+          req.session['passport'] = {};
         })
         .authenticate();
     });
@@ -58,8 +59,9 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.session = {};
-          req._passport.session.user = '123456';
+          req.session = {};
+          req.session['passport'] = {};
+          req.session['passport'].user = '123456';
         })
         .authenticate();
     });
@@ -74,8 +76,8 @@ describe('SessionStrategy', function() {
     });
     
     it('should maintain session', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(request._passport.session.user).to.equal('123456');
+      expect(request.session['passport']).to.be.an('object');
+      expect(request.session['passport'].user).to.equal('123456');
     });
   });
   
@@ -97,8 +99,9 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.session = {};
-          req._passport.session.user = 0;
+          req.session = {};
+          req.session['passport'] = {};
+          req.session['passport'].user = 0;
         })
         .authenticate();
     });
@@ -113,8 +116,8 @@ describe('SessionStrategy', function() {
     });
     
     it('should maintain session', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(request._passport.session.user).to.equal(0);
+      expect(request.session['passport']).to.be.an('object');
+      expect(request.session['passport'].user).to.equal(0);
     });
   });
   
@@ -136,8 +139,9 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.session = {};
-          req._passport.session.user = '123456';
+          req.session = {};
+          req.session['passport'] = {};
+          req.session['passport'].user = '123456';
         })
         .authenticate();
     });
@@ -151,8 +155,8 @@ describe('SessionStrategy', function() {
     });
     
     it('should remove user from session', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(request._passport.session.user).to.be.undefined;
+      expect(request.session['passport']).to.be.an('object');
+      expect(request.session['passport'].user).to.be.undefined;
     });
   });
   
@@ -175,8 +179,9 @@ describe('SessionStrategy', function() {
           req._passport = {};
           req._passport.instance = {};
           req._passport.instance._userProperty = 'currentUser';
-          req._passport.session = {};
-          req._passport.session.user = '123456';
+          req.session = {};
+          req.session['passport'] = {};
+          req.session['passport'].user = '123456';
         })
         .authenticate();
     });
@@ -213,8 +218,9 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.session = {};
-          req._passport.session.user = '123456';
+          req.session = {};
+          req.session['passport'] = {};
+          req.session['passport'].user = '123456';
         })
         .authenticate();
     });
@@ -229,8 +235,8 @@ describe('SessionStrategy', function() {
     });
     
     it('should maintain session', function() {
-      expect(request._passport.session).to.be.an('object');
-      expect(request._passport.session.user).to.equal('123456');
+      expect(request.session['passport']).to.be.an('object');
+      expect(request.session['passport'].user).to.equal('123456');
     });
   });
   

--- a/test/strategies/session.test.js
+++ b/test/strategies/session.test.js
@@ -178,7 +178,7 @@ describe('SessionStrategy', function() {
           
           req._passport = {};
           req._passport.instance = {};
-          req._passport.instance._userProperty = 'currentUser';
+          req._userProperty = 'currentUser';
           req.session = {};
           req.session['passport'] = {};
           req.session['passport'].user = '123456';


### PR DESCRIPTION
This PR removes the monkey patching of node's `http.IncomingMessage`.  Instead of that, it adds methods to each request as it passes through middleware, in a way that fits the patterns in other Express middleware.

In addition to that, session internals have been refactored to operate on `req.session` directly, rather than a pointer maintained at `req._passport.session`.  This is part of an ongoing effort to refactor away from `req._passport` and clean up internals which use that.

For those same reasons, use of `this._passport.instance._userProperty` has been refactored to `req._userProperty`.  This cleans up internals while also allowing the possibility of setting a custom user property per-request via middleware, rather than globally for all requests processed through the singleton Passport instance.