### PR TITLE
Remove need to call `passport.initialize()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+
+- `authenticate()` middleware, rather than `initialize()` middleware, extends
+request with `login()`, `logIn()`, `logout()`, `logOut()`, `isAuthenticated()`,
+and `isUnauthenticated()` functions.
+
 ## [0.5.0] - 2021-09-23
 ### Changed
 

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -37,7 +37,7 @@ req.logIn = function(user, options, done) {
     if (typeof done != 'function') { throw new Error('req#login requires a callback function'); }
     
     var self = this;
-    this._passport.instance._sm.logIn(this, user, function(err) {
+    this.sessionManager.logIn(this, user, function(err) {
       if (err) { self[property] = null; return done(err); }
       done();
     });
@@ -57,7 +57,7 @@ req.logOut = function() {
   
   this[property] = null;
   if (this._passport) {
-    this._passport.instance._sm.logOut(this);
+    this.sessionManager.logOut(this);
   }
 };
 

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -33,7 +33,6 @@ req.logIn = function(user, options, done) {
   
   this[property] = user;
   if (session && this._sessionManager) {
-    //if (!this._sessionManager) { throw new Error('Login sessions require a session manager'); }
     if (typeof done != 'function') { throw new Error('req#login requires a callback function'); }
     
     var self = this;

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -33,11 +33,11 @@ req.logIn = function(user, options, done) {
   
   this[property] = user;
   if (session) {
-    if (!this.sessionManager) { throw new Error('Login sessions require a session manager'); }
+    if (!this._sessionManager) { throw new Error('Login sessions require a session manager'); }
     if (typeof done != 'function') { throw new Error('req#login requires a callback function'); }
     
     var self = this;
-    this.sessionManager.logIn(this, user, function(err) {
+    this._sessionManager.logIn(this, user, function(err) {
       if (err) { self[property] = null; return done(err); }
       done();
     });
@@ -56,8 +56,8 @@ req.logOut = function() {
   var property = this._userProperty || 'user';
   
   this[property] = null;
-  if (this.sessionManager) {
-    this.sessionManager.logOut(this);
+  if (this._sessionManager) {
+    this._sessionManager.logOut(this);
   }
 };
 

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -32,8 +32,8 @@ req.logIn = function(user, options, done) {
   var session = (options.session === undefined) ? true : options.session;
   
   this[property] = user;
-  if (session) {
-    if (!this._sessionManager) { throw new Error('Login sessions require a session manager'); }
+  if (session && this._sessionManager) {
+    //if (!this._sessionManager) { throw new Error('Login sessions require a session manager'); }
     if (typeof done != 'function') { throw new Error('req#login requires a callback function'); }
     
     var self = this;

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -33,7 +33,7 @@ req.logIn = function(user, options, done) {
   
   this[property] = user;
   if (session) {
-    if (!this._passport) { throw new Error('passport.initialize() middleware not in use'); }
+    if (!this.sessionManager) { throw new Error('Login sessions require a session manager'); }
     if (typeof done != 'function') { throw new Error('req#login requires a callback function'); }
     
     var self = this;
@@ -56,7 +56,7 @@ req.logOut = function() {
   var property = this._userProperty || 'user';
   
   this[property] = null;
-  if (this._passport) {
+  if (this.sessionManager) {
     this.sessionManager.logOut(this);
   }
 };

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -92,6 +92,13 @@ module.exports = function authenticate(passport, name, options, callback) {
   }
   
   return function authenticate(req, res, next) {
+    req.login =
+    req.logIn = req.logIn || IncomingMessageExt.logIn;
+    req.logout =
+    req.logOut = req.logOut || IncomingMessageExt.logOut;
+    req.isAuthenticated = req.isAuthenticated || IncomingMessageExt.isAuthenticated;
+    req.isUnauthenticated = req.isUnauthenticated || IncomingMessageExt.isUnauthenticated;
+    
     // expose session manager
     req.sessionManager = passport._sm;
     

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -92,6 +92,9 @@ module.exports = function authenticate(passport, name, options, callback) {
   }
   
   return function authenticate(req, res, next) {
+    // expose session manager
+    req.sessionManager = passport._sm;
+    
     // accumulator for failures from each strategy in the chain
     var failures = [];
     

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -99,8 +99,7 @@ module.exports = function authenticate(passport, name, options, callback) {
     req.isAuthenticated = req.isAuthenticated || IncomingMessageExt.isAuthenticated;
     req.isUnauthenticated = req.isUnauthenticated || IncomingMessageExt.isUnauthenticated;
     
-    // expose session manager
-    req.sessionManager = passport._sm;
+    req._sessionManager = passport._sm;
     
     // accumulator for failures from each strategy in the chain
     var failures = [];

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -56,6 +56,9 @@ module.exports = function initialize(passport, options) {
     req.isAuthenticated = IncomingMessageExt.isAuthenticated;
     req.isUnauthenticated = IncomingMessageExt.isUnauthenticated;
     
+    // expose session manager
+    req.sessionManager = passport._sm;
+    
     if (options.userProperty) {
       req._userProperty = options.userProperty;
     }

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -49,13 +49,6 @@ module.exports = function initialize(passport, options) {
   options = options || {};
   
   return function initialize(req, res, next) {
-    req.login =
-    req.logIn = IncomingMessageExt.logIn;
-    req.logout =
-    req.logOut = IncomingMessageExt.logOut;
-    req.isAuthenticated = IncomingMessageExt.isAuthenticated;
-    req.isUnauthenticated = IncomingMessageExt.isUnauthenticated;
-    
     if (options.userProperty) {
       req._userProperty = options.userProperty;
     }

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -56,9 +56,6 @@ module.exports = function initialize(passport, options) {
     req.isAuthenticated = IncomingMessageExt.isAuthenticated;
     req.isUnauthenticated = IncomingMessageExt.isUnauthenticated;
     
-    // expose session manager
-    req.sessionManager = passport._sm;
-    
     if (options.userProperty) {
       req._userProperty = options.userProperty;
     }

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -59,9 +59,6 @@ module.exports = function initialize(passport, options) {
     if (options.userProperty) {
       req._userProperty = options.userProperty;
     }
-    
-    req._passport = {};
-    req._passport.instance = passport;
 
     next();
   };

--- a/lib/strategies/session.js
+++ b/lib/strategies/session.js
@@ -43,7 +43,7 @@ util.inherits(SessionStrategy, Strategy);
  * @api protected
  */
 SessionStrategy.prototype.authenticate = function(req, options) {
-  if (!req._passport) { return this.error(new Error('passport.initialize() middleware not in use')); }
+  if (!req.session) { return this.error(new Error('Login sessions require session support. Did you forget to use `express-session` middleware?')); }
   options = options || {};
 
   var self = this, 

--- a/test/authenticator.middleware.test.js
+++ b/test/authenticator.middleware.test.js
@@ -42,12 +42,6 @@ describe('Authenticator', function() {
       it('should not initialize namespace within session', function() {
         expect(request.session.passport).to.be.undefined;
       });
-    
-      it('should expose authenticator on internal request property', function() {
-        expect(request._passport).to.be.an('object');
-        expect(request._passport.instance).to.be.an.instanceOf(Authenticator);
-        expect(request._passport.instance).to.equal(passport);
-      });
     });
     
     describe('handling a request with custom user property', function() {
@@ -77,12 +71,6 @@ describe('Authenticator', function() {
     
       it('should not initialize namespace within session', function() {
         expect(request.session.passport).to.be.undefined;
-      });
-    
-      it('should expose authenticator on internal request property', function() {
-        expect(request._passport).to.be.an('object');
-        expect(request._passport.instance).to.be.an.instanceOf(Authenticator);
-        expect(request._passport.instance).to.equal(passport);
       });
     });
     

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -332,6 +332,7 @@ describe('http.ServerRequest', function() {
       });
     });
     
+    /*
     describe('establishing a session, without passport.initialize() middleware', function() {
       var req = new Object();
       req.login = request.login;
@@ -340,9 +341,10 @@ describe('http.ServerRequest', function() {
       it('should throw an exception', function() {
         expect(function() {
           req.login(user, function(err) {});
-        }).to.throw(Error, 'Login sessions require a session manager');
+        }).to.throw(Error, 'passport.initialize() middleware not in use');
       });
     });
+    */
     
     describe('establishing a session, but not passing a callback argument', function() {
       var passport = new Passport();

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -340,7 +340,7 @@ describe('http.ServerRequest', function() {
       it('should throw an exception', function() {
         expect(function() {
           req.login(user, function(err) {});
-        }).to.throw(Error, 'passport.initialize() middleware not in use');
+        }).to.throw(Error, 'Login sessions require a session manager');
       });
     });
     
@@ -354,6 +354,7 @@ describe('http.ServerRequest', function() {
       req.login = request.login;
       req._passport = {};
       req._passport.instance = passport;
+      req.sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -201,7 +201,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req.sessionManager = passport._sm;
+      req._sessionManager = passport._sm;
       req.session = {};
       
       var error;
@@ -247,7 +247,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req.sessionManager = passport._sm;
+      req._sessionManager = passport._sm;
       req.session = {};
       req._userProperty = 'currentUser';
       
@@ -298,7 +298,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
-      req.sessionManager = passport._sm;
+      req._sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       
@@ -354,7 +354,7 @@ describe('http.ServerRequest', function() {
       req.login = request.login;
       req._passport = {};
       req._passport.instance = passport;
-      req.sessionManager = passport._sm;
+      req._sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       
@@ -382,7 +382,7 @@ describe('http.ServerRequest', function() {
       req.user = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = passport;
-      req.sessionManager = passport._sm;
+      req._sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       req.session['passport'].user = '1';
@@ -414,7 +414,7 @@ describe('http.ServerRequest', function() {
       req._passport = {};
       req._passport.instance = passport;
       req._userProperty = 'currentUser';
-      req.sessionManager = passport._sm;
+      req._sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       req.session['passport'].user = '1';

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -201,6 +201,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
+      req.sessionManager = passport._sm;
       req.session = {};
       
       var error;
@@ -246,6 +247,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
+      req.sessionManager = passport._sm;
       req.session = {};
       req._userProperty = 'currentUser';
       
@@ -296,6 +298,7 @@ describe('http.ServerRequest', function() {
       req.isUnauthenticated = request.isUnauthenticated;
       req._passport = {};
       req._passport.instance = passport;
+      req.sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       
@@ -378,6 +381,7 @@ describe('http.ServerRequest', function() {
       req.user = { id: '1', username: 'root' };
       req._passport = {};
       req._passport.instance = passport;
+      req.sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       req.session['passport'].user = '1';
@@ -409,6 +413,7 @@ describe('http.ServerRequest', function() {
       req._passport = {};
       req._passport.instance = passport;
       req._userProperty = 'currentUser';
+      req.sessionManager = passport._sm;
       req.session = {};
       req.session['passport'] = {};
       req.session['passport'].user = '1';

--- a/test/middleware/initialize.test.js
+++ b/test/middleware/initialize.test.js
@@ -31,12 +31,6 @@ describe('middleware/initialize', function() {
     it('should not error', function() {
       expect(error).to.be.undefined;
     });
-    
-    it('should expose authenticator on internal request property', function() {
-      expect(request._passport).to.be.an('object');
-      expect(request._passport.instance).to.be.an.instanceOf(Passport);
-      expect(request._passport.instance).to.equal(passport);
-    });
   });
   
   describe('handling a request with a new session', function() {
@@ -63,12 +57,6 @@ describe('middleware/initialize', function() {
     
     it('should not initialize namespace within session', function() {
       expect(request.session.passport).to.be.undefined;
-    });
-    
-    it('should expose authenticator on internal request property', function() {
-      expect(request._passport).to.be.an('object');
-      expect(request._passport.instance).to.be.an.instanceOf(Passport);
-      expect(request._passport.instance).to.equal(passport);
     });
   });
   
@@ -101,12 +89,6 @@ describe('middleware/initialize', function() {
       expect(Object.keys(request.session.passport)).to.have.length(1);
       expect(request.session.passport.user).to.equal('123456');
     });
-    
-    it('should expose authenticator on internal request property', function() {
-      expect(request._passport).to.be.an('object');
-      expect(request._passport.instance).to.be.an.instanceOf(Passport);
-      expect(request._passport.instance).to.equal(passport);
-    });
   });
   
   describe('handling a request with an existing session using custom session key', function() {
@@ -138,12 +120,6 @@ describe('middleware/initialize', function() {
       expect(request.session.authentication).to.be.an('object');
       expect(Object.keys(request.session.authentication)).to.have.length(1);
       expect(request.session.authentication.user).to.equal('123456');
-    });
-    
-    it('should expose authenticator on internal request property', function() {
-      expect(request._passport).to.be.an('object');
-      expect(request._passport.instance).to.be.an.instanceOf(Passport);
-      expect(request._passport.instance).to.equal(passport);
     });
   });
   

--- a/test/strategies/session.test.js
+++ b/test/strategies/session.test.js
@@ -257,7 +257,7 @@ describe('SessionStrategy', function() {
   
     it('should error', function() {
       expect(error).to.be.an.instanceOf(Error);
-      expect(error.message).to.equal('passport.initialize() middleware not in use');
+      expect(error.message).to.equal('Login sessions require session support. Did you forget to use `express-session` middleware?');
     });
     
     it('should not set user on request', function() {


### PR DESCRIPTION
This PR continues the work started in #848, completing the refactor away from using `req._passport`.

Following the patterns of other middleware, the HTTP request is now extended when it passes through `authenticate()` middleware, rather than `initialize()`.  This removes the need to use `passport.initialize()` entirely, which simplifies the app-level middleware stack.  It should also make it easier to adapt Passport to non-Express web frameworks.