### PR TITLE
Use built-in body parser of express

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ middleware must also be used.
 var app = express();
 app.use(require('serve-static')(__dirname + '/../../public'));
 app.use(require('cookie-parser')());
-app.use(require('body-parser').urlencoded({ extended: true }));
+app.use(express.json());
+app.use(express.urlencoded({extended: true}));
 app.use(require('express-session')({ secret: 'keyboard cat', resave: true, saveUninitialized: true }));
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
Since express v4.16.0 (released over 4 years ago) `body parser` has been re-added under the methods `express.json()` and `express.urlencoded()`. So I think it would be a good practice to use the built-ins.

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
