### PR TITLE
Extend request in initialize middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- `initialize()` middleware extends request with `login()`, `logIn()`,
+`logout()`, `logOut()`, `isAuthenticated()`, and `isUnauthenticated()` functions
+again, reverting change from 0.5.1.
 
 ## [0.5.2] - 2021-12-16
 ### Fixed

--- a/lib/middleware/initialize.js
+++ b/lib/middleware/initialize.js
@@ -49,6 +49,15 @@ module.exports = function initialize(passport, options) {
   options = options || {};
   
   return function initialize(req, res, next) {
+    req.login =
+    req.logIn = req.logIn || IncomingMessageExt.logIn;
+    req.logout =
+    req.logOut = req.logOut || IncomingMessageExt.logOut;
+    req.isAuthenticated = req.isAuthenticated || IncomingMessageExt.isAuthenticated;
+    req.isUnauthenticated = req.isUnauthenticated || IncomingMessageExt.isUnauthenticated;
+    
+    req._sessionManager = passport._sm;
+    
     if (options.userProperty) {
       req._userProperty = options.userProperty;
     }


### PR DESCRIPTION
This PR reverts a change in v0.5.1, so that `passport.initialize()` now (as it did before) extends the request with `login()`, etc. functions.  Fixes #881.