### PR TITLE
Add lambda-api integration

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -91,6 +91,13 @@ module.exports = function authenticate(passport, name, options, callback) {
     multi = false;
   }
   
+  function isLambdaApiResponse(res) {
+    return typeof res === 'object' &&
+      typeof res.setHeader === 'undefined' &&
+      typeof res.location === 'function' &&
+      typeof res.end === 'undefined';
+  }
+  
   return function authenticate(req, res, next) {
     req.login =
     req.logIn = req.logIn || IncomingMessageExt.logIn;
@@ -160,7 +167,7 @@ module.exports = function authenticate(passport, name, options, callback) {
         failure = failures[j];
         challenge = failure.challenge;
         status = failure.status;
-          
+        
         rstatus = rstatus || status;
         if (typeof challenge == 'string') {
           rchallenge.push(challenge);
@@ -326,8 +333,15 @@ module.exports = function authenticate(passport, name, options, callback) {
         //       Express 4.x: res.redirect(status, url)
         //         - all versions (as of 4.8.7) continue to accept res.redirect(url, status)
         //           but issue deprecated versions
+        var statusCode = status || 302;
         
-        res.statusCode = status || 302;
+        if (isLambdaApiResponse(res)) {
+          res.location(url).status(statusCode);
+          res.send({});
+          return;
+        }
+
+        res.statusCode = statusCode;
         res.setHeader('Location', url);
         res.setHeader('Content-Length', '0');
         res.end();


### PR DESCRIPTION
Support for [lambda-api](https://github.com/jeremydaly/lambda-api), currently redirects are not working, due to lack of methods in this library.
### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
