### PR TITLE
Bug fix in middleware/authenticate

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -187,13 +187,13 @@ module.exports = function authenticate(passport, name, options, callback) {
       // within the context of the HTTP request/response pair.
       var strategy, prototype;
       if (typeof layer.authenticate == 'function') {
-        strategy = layer;
+        prototype = layer;
       } else {
         prototype = passport._strategy(layer);
         if (!prototype) { return next(new Error('Unknown authentication strategy "' + layer + '"')); }
-        
-        strategy = Object.create(prototype);
       }
+
+      strategy = Object.create(prototype);
       
       
       // ----- BEGIN STRATEGY AUGMENTATION -----

--- a/test/middleware/authenticate.strategy.modification.test.js
+++ b/test/middleware/authenticate.strategy.modification.test.js
@@ -1,0 +1,162 @@
+/* global describe, it, expect, before */
+
+/*
+These tests validate that when authenticate(passport, strategy) is called, the
+strategy object is not modified. (The authenticate function should copy the object using Object.create())
+
+Scenarios:
+| # | strategy param | use called | description                                                                                    |
+| 1 | string         | true       | authenticate called, passing strategy as a string                                              |
+| 2 | object         | true       | authenticate called, passing strategy as an object                                             |
+| 3 | objeect        | false      | authenticate called, passing strategy as an object, without calling passport.use() on strategy |
+
+Validations:
+    strategy.authenticate should not be modified
+    if set by strategy constructor, strategy.name should not be modified
+    strategy.success should not be modified/defined
+    strategy.fail should not be modified/defined
+    strategy.redirect should not be modified/defined
+    strategy.pass should not be modified/defined
+    strategy.error should not be modified/defined
+*/
+
+var chai = require('chai')
+  , authenticate = require('../../lib/middleware/authenticate')
+  , Passport = require('../..').Passport;
+
+  describe('middleware/authenticate', function(){
+    describe('when called, passing strategy as a string', function(){
+  
+      function Strategy() {
+      }
+      var authenticateFunc;
+      Strategy.prototype.authenticate = authenticateFunc = function(req) {
+        var user = { id: '1', username: 'jaredhanson' };
+        this.success(user);
+      };
+  
+      const strategy = new Strategy();
+  
+      var passport = new Passport();
+  
+      passport.use('strategy', strategy)
+      
+      var request, error;
+  
+      before(function(done) {
+        chai.connect.use(authenticate(passport, 'strategy'))
+          .req(function(req) {
+            request = req;
+            req.logIn = function(user, options, done) {
+              this.user = user;
+              done();
+            };
+          })
+          .next(function(err) {
+            error = err;
+            done();
+          })
+          .dispatch();
+      });
+      
+      it('should not modify the strategy', function(){
+        expect(strategy.authenticate).to.equal(authenticateFunc);
+        expect(strategy.success).to.be.undefined
+        expect(strategy.fail).to.be.undefined
+        expect(strategy.redirect).to.be.undefined
+        expect(strategy.pass).to.be.undefined
+        expect(strategy.error).to.be.undefined
+      });
+    })
+
+    describe('when called, passing strategy as an object', function(){
+  
+        function Strategy() {
+            this.name = 'strategy'
+        }
+        var authenticateFunc;
+        Strategy.prototype.authenticate = authenticateFunc = function(req) {
+          var user = { id: '1', username: 'jaredhanson' };
+          this.success(user);
+        };
+    
+        const strategy = new Strategy();
+
+        const strategyName = strategy.name
+    
+        var passport = new Passport();
+    
+        passport.use(strategy)
+        
+        var request, error;
+    
+        before(function(done) {
+          chai.connect.use(authenticate(passport, strategy))
+            .req(function(req) {
+              request = req;
+              req.logIn = function(user, options, done) {
+                this.user = user;
+                done();
+              };
+            })
+            .next(function(err) {
+              error = err;
+              done();
+            })
+            .dispatch();
+        });
+        
+        it('should not modify the strategy', function(){
+          expect(strategy.authenticate).to.equal(authenticateFunc);
+          expect(strategy.name).to.equal(strategyName);
+          expect(strategy.success).to.be.undefined
+          expect(strategy.fail).to.be.undefined
+          expect(strategy.redirect).to.be.undefined
+          expect(strategy.pass).to.be.undefined
+          expect(strategy.error).to.be.undefined
+        });
+      })
+
+      describe('when called, passing strategy as an object, without calling passport.use() on strategy', function(){
+  
+        function Strategy() {
+        }
+        var authenticateFunc;
+        Strategy.prototype.authenticate = authenticateFunc = function(req) {
+          var user = { id: '1', username: 'jaredhanson' };
+          this.success(user);
+        };
+    
+        const strategy = new Strategy();
+    
+        var passport = new Passport();
+        
+        var request, error;
+    
+        before(function(done) {
+          chai.connect.use(authenticate(passport, strategy))
+            .req(function(req) {
+              request = req;
+              req.logIn = function(user, options, done) {
+                this.user = user;
+                done();
+              };
+            })
+            .next(function(err) {
+              error = err;
+              done();
+            })
+            .dispatch();
+        });
+        
+        it('should not modify the strategy', function(){
+          expect(strategy.authenticate).to.equal(authenticateFunc);
+          expect(strategy.success).to.be.undefined
+          expect(strategy.fail).to.be.undefined
+          expect(strategy.redirect).to.be.undefined
+          expect(strategy.pass).to.be.undefined
+          expect(strategy.error).to.be.undefined
+        });
+      })
+  });
+  


### PR DESCRIPTION
-Fix bug in middelware/authenticate where strategy was not copied using Object.create() when passed
in to autenticate() as an object.
-add tests to validate that calling authenticate() does not modify the original strategy object

** READ THIS FIRST! **

#### Are you implementing a new feature?

Requests for new features should first be discussed on the [developer forum](https://github.com/passport/develop).
This allows the community to gather feedback and assess whether or not there is
an existing way to achieve the desired functionality.

If it is determined that a new feature needs to be implemented, include a link
to the relevant discussion along with the pull request.

#### Is this a security patch?

Do not open pull requests that might have security implications.  Potential
security vulnerabilities should be reported privately to jaredhanson@gmail.com.
Once any vulerabilities have been repaired, the details will be disclosed
publicly in a responsible manner.  This also allows time for coordinating with
affected parties in order to mitigate negative consequences.


If neither of the above two scenarios apply to your situation, you should open
a pull request.  Delete this paragraph and the text above, and fill in the
information requested below.

<!-- Provide a brief summary of the request in the title field above. -->

<!-- Provide a detailed description of your use case, including as much -->
<!-- detail as possible about what you are trying to accomplish and why. -->
<!-- If this patch closes an open issue, include a reference to the issue -->
<!-- number. -->

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
