### PR TITLE
Fix race condition in logOut. Fixes #1004

### DIFF
--- a/lib/sessionmanager.js
+++ b/lib/sessionmanager.js
@@ -86,8 +86,15 @@ SessionManager.prototype.logOut = function(req, options, cb) {
       }
       if (options.keepSessionInfo) {
         merge(req.session, prevSession);
+        req.session.save(function(err) {
+          if (err) {
+            return cb(err);
+          }
+          cb();
+        });
+      } else {
+        cb();
       }
-      cb();
     });
   });
 }


### PR DESCRIPTION
**Update: I botched the previous PR so I'm re-issuing this one.**

This fixes a race condition where the session is saved but then modified again in the `keepSessionInfo` branch and the callback is called before save is called again. This patch issues a second save in the `keepSessionInfo` eliminating the race condition. Fixes #1004.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [x] The automated test suite (`$ make test`) executes successfully.

I have left the following unchecked with an explanation:

- The automated code linting (`$ make lint`) executes successfully.

When I ran `make lint` I encountered an error because `jshint` is expected on the path (as opposed to being installed by npm and being called with `npx` for example). When I added it to the path it threw several errors but none of them were related to this patch. These errors are all from the existing codebase. Maybe I have run this in error somehow or I'm missing a config file.

- I have added test cases which verify the correct operation of this feature or patch.

I can't see how to replicate the failing condition in the current tests. I'm looking at `request.test.js` and I'm unsure how to simulate a backend which takes a while to set the values. Any guidance here welcome.

- I have added documentation pertaining to this feature or patch.

I do not think any documentation changes will be necessary for this under-the-hood fix which will be transparent to the user.