### PR TITLE
Remove arguments.callee from AuthenticationError

### DIFF
--- a/lib/errors/authenticationerror.js
+++ b/lib/errors/authenticationerror.js
@@ -6,7 +6,7 @@
  */
 function AuthenticationError(message, status) {
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, AuthenticationError);
   this.name = 'AuthenticationError';
   this.message = message;
   this.status = status || 401;


### PR DESCRIPTION
We have a problem using export on our systems, when a bad token is sent to the Authorization system it throws the following error: 

` TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them`

The error seems to be caused by AuthenticationError captureStackTrace which uses arguments.callee.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch. --- not concerned
- [ ] I have added documentation pertaining to this feature or patch. -- not concerned
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully. -- some lint errors however they do not concern the code i edited
