### PR TITLE
Update repository URL metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://www.passportjs.org/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jaredhanson/passport.git"
+    "url": "git+https://github.com/jaredhanson/passport.git"
   },
   "bugs": {
     "url": "https://github.com/jaredhanson/passport/issues"


### PR DESCRIPTION
Summary:
- update the package repository URL from the legacy `git://` protocol to `git+https://`
- keep the existing homepage and bugs metadata unchanged

Validation:
- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/jaredhanson/passport.git') throw new Error(p.repository.url); if (p.bugs.url !== 'https://github.com/jaredhanson/passport/issues') throw new Error(p.bugs.url); if (p.homepage !== 'https://www.passportjs.org/') throw new Error(p.homepage); console.log('metadata ok');"`
- `git -c core.autocrlf=false diff --check`